### PR TITLE
Refactor/n step rollout

### DIFF
--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -9,26 +9,26 @@ class A2C(Agent):
             v,
             policy,
             n_steps=4,
-            update_frequency=4,
+            batch_size=54,
             discount_factor=0.99
     ):
         self.features = features
         self.v = v
         self.policy = policy
         self.n_steps = n_steps
-        self.update_frequency = update_frequency
+        self.batch_size = batch_size
         self.discount_factor = discount_factor
         self._buffer = self._make_buffer()
 
     def act(self, states, rewards, info=None):
         features = self.features(states)
         self._buffer.store(features, rewards)
-        if self._buffer.is_full():
+        if len(self._buffer) >= self.batch_size:
             self._train()
         return self.policy(features)
 
     def _train(self):
-        features, next_features, returns, rollout_lengths = self._buffer.sample(-1)
+        features, next_features, returns, rollout_lengths = self._buffer.sample(self.batch_size)
         td_errors = (
             returns
             + (self.discount_factor ** rollout_lengths) * self.v.eval(next_features)
@@ -41,6 +41,5 @@ class A2C(Agent):
     def _make_buffer(self):
         return NStepBuffer(
             self.n_steps,
-            self.update_frequency,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -36,7 +36,7 @@ class A2C(Agent):
         next_features = self.features(next_states)
         td_errors = (
             returns
-            + (self.discount_factor ** rollout_lengths) 
+            + (self.discount_factor ** rollout_lengths)
             * self.v.eval(next_features)
             - self.v(features)
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -23,12 +23,13 @@ class A2C(Agent):
     def act(self, states, rewards, info=None):
         features = self.features(states)
         self._buffer.store(features, rewards)
-        if self._buffer.is_full():
-            self._train()
+        batch_size = len(states) * self.update_frequency
+        if len(self._buffer) >= batch_size:
+            self._train(batch_size)
         return self.policy(features)
 
-    def _train(self):
-        features, next_features, returns, rollout_lengths = self._buffer.sample(-1)
+    def _train(self, batch_size):
+        features, next_features, returns, rollout_lengths = self._buffer.sample(batch_size)
         td_errors = (
             returns
             + (self.discount_factor ** rollout_lengths) * self.v.eval(next_features)
@@ -41,6 +42,5 @@ class A2C(Agent):
     def _make_buffer(self):
         return NStepBuffer(
             self.n_steps,
-            self.update_frequency,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -9,26 +9,26 @@ class A2C(Agent):
             v,
             policy,
             n_steps=4,
-            batch_size=54,
+            update_frequency=4,
             discount_factor=0.99
     ):
         self.features = features
         self.v = v
         self.policy = policy
         self.n_steps = n_steps
-        self.batch_size = batch_size
+        self.update_frequency = update_frequency
         self.discount_factor = discount_factor
         self._buffer = self._make_buffer()
 
     def act(self, states, rewards, info=None):
         features = self.features(states)
         self._buffer.store(features, rewards)
-        if len(self._buffer) >= self.batch_size:
+        if self._buffer.is_full():
             self._train()
         return self.policy(features)
 
     def _train(self):
-        features, next_features, returns, rollout_lengths = self._buffer.sample(self.batch_size)
+        features, next_features, returns, rollout_lengths = self._buffer.sample(-1)
         td_errors = (
             returns
             + (self.discount_factor ** rollout_lengths) * self.v.eval(next_features)
@@ -41,5 +41,6 @@ class A2C(Agent):
     def _make_buffer(self):
         return NStepBuffer(
             self.n_steps,
+            self.update_frequency,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -21,19 +21,19 @@ class A2C(Agent):
         self._buffer = self._make_buffer()
 
     def act(self, states, rewards, info=None):
-        features = self.features(states)
-        self._buffer.store(features, rewards)
+        self._buffer.store(states, rewards)
         batch_size = len(states) * self.update_frequency
         if len(self._buffer) >= batch_size:
             self._train(batch_size)
-        return self.policy(features)
+        return self.policy(self.features(states))
 
     def _train(self, batch_size):
-        features, next_features, returns, rollout_lengths = self._buffer.sample(batch_size)
+        states, next_states, returns, rollout_lengths = self._buffer.sample(batch_size)
         td_errors = (
             returns
-            + (self.discount_factor ** rollout_lengths) * self.v.eval(next_features)
-            - self.v(features)
+            + (self.discount_factor ** rollout_lengths) 
+            * self.v.eval(self.features(next_states))
+            - self.v(self.features(states))
         )
         self.v.reinforce(td_errors, retain_graph=True)
         self.policy.reinforce(td_errors)

--- a/all/approximation/v_network.py
+++ b/all/approximation/v_network.py
@@ -1,3 +1,5 @@
+import os
+from datetime import datetime
 import torch
 from torch import optim
 from torch.nn import utils
@@ -5,9 +7,6 @@ from torch.nn.functional import mse_loss
 from tensorboardX import SummaryWriter
 from all.layers import ListNetwork
 from .v_function import ValueFunction
-
-import os
-from datetime import datetime
 
 class ValueNetwork(ValueFunction):
     def __init__(self, model, optimizer=None, loss=mse_loss, clip_grad=0):
@@ -61,7 +60,7 @@ class ValueNetwork(ValueFunction):
             i += 1
         if items != batch_size:
             raise ValueError("Incompatible batch size.")
-        
+
         cache = torch.cat(self._cache[:i])
         self._cache = self._cache[i:]
 

--- a/all/approximation/v_network_test.py
+++ b/all/approximation/v_network_test.py
@@ -38,14 +38,17 @@ class TestQNetwork(unittest.TestCase):
             torch.randn(1, STATE_DIM),
             None,
             torch.randn(1, STATE_DIM),
+            None,
             None
         ]
-        self.v(states)
+        self.v(states[0:2])
+        self.v(states[2:4])
+        self.v(states[4:6])
         self.v.reinforce(torch.tensor([1, 2]).float())
-        self.v.reinforce(torch.tensor([1]).float())
+        self.v.reinforce(torch.tensor([1, 1]).float())
         self.v.reinforce(torch.tensor([1, 2]).float())
         with self.assertRaises(Exception):
-            self.v.reinforce(torch.tensor([1, 2, 3]).float())
+            self.v.reinforce(torch.tensor([1, 2]).float())
 
 if __name__ == '__main__':
     unittest.main()

--- a/all/approximation/v_network_test.py
+++ b/all/approximation/v_network_test.py
@@ -32,6 +32,20 @@ class TestQNetwork(unittest.TestCase):
         tt.assert_almost_equal(result, torch.tensor(
             [0.8042525, 0.4606972, 0., 0.0714759, 0.]))
 
+    def test_multi_reinforce(self):
+        states = [
+            torch.randn(1, STATE_DIM),
+            torch.randn(1, STATE_DIM),
+            None,
+            torch.randn(1, STATE_DIM),
+            None
+        ]
+        self.v(states)
+        self.v.reinforce(torch.tensor([1, 2]).float())
+        self.v.reinforce(torch.tensor([1]).float())
+        self.v.reinforce(torch.tensor([1, 2]).float())
+        with self.assertRaises(Exception):
+            self.v.reinforce(torch.tensor([1, 2, 3]).float())
 
 if __name__ == '__main__':
     unittest.main()

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -56,7 +56,7 @@ class NStepBuffer():
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)
         lengths = self._lengths[0:batch_size]
-        lengths = torch.tensor(lengths, device=rewards[0].device)
+        lengths = torch.tensor(lengths, device=rewards[0].device, dtype=torch.float)
 
         self._states = self._states[batch_size:]
         self._next_states = self._next_states[batch_size:]

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -7,6 +7,7 @@ class NStepBuffer():
         self.gamma = discount_factor
         self.i = 0
         self._states = []
+        self._actions = []
         self._rewards = []
         self._next_states = []
         self._lengths = []
@@ -15,34 +16,34 @@ class NStepBuffer():
     def __len__(self):
         return len(self._states)
 
-    def store(self, states, rewards):
+    def store(self, states, actions, rewards):
         # move states that are ready out of temp buffer
         if len(self._temp) == self.n:
             discount = self.gamma ** (self.n - 1)
             for i, v in enumerate(self._temp[0]):
-                state, reward, last_state, length = v
+                state, action, reward, last_state, length = v
                 if last_state is None:
-                    self._store(state, reward, last_state, length)
+                    self._store(state, action, reward, last_state, length)
                 else:
                     reward += discount * rewards[i]
                     last_state = states[i]
-                    self._store(state, reward, last_state, length + 1)
+                    self._store(state, action, reward, last_state, length + 1)
             self._temp = self._temp[1:]
 
         for t, _temp in enumerate(self._temp):
             discount = self.gamma ** (len(self._temp) - 1 - t)
             for i, v in enumerate(_temp):
-                state, reward, last_state, length = v
+                state, action, reward, last_state, length = v
                 if last_state is not None:
                     reward += discount * rewards[i]
                     last_state = states[i]
                     length += 1
-                _temp[i] = (state, reward, last_state, length)
+                _temp[i] = (state, action, reward, last_state, length)
 
         self._temp.append([
-            (state, reward, next_state, 0)
-            for state, reward, next_state
-            in zip(states, rewards * 0, states)
+            (state, action, reward, next_state, 0)
+            for state, action, reward, next_state
+            in zip(states, actions, rewards * 0, states)
         ])
 
         return self
@@ -52,6 +53,8 @@ class NStepBuffer():
             raise Exception("Not enough states for batch size!")
 
         states = self._states[0:batch_size]
+        actions = self._actions[0:batch_size]
+        actions = torch.tensor(actions, device=actions[0].device)
         next_states = self._next_states[0:batch_size]
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)
@@ -59,15 +62,17 @@ class NStepBuffer():
         lengths = torch.tensor(lengths, device=rewards[0].device, dtype=torch.float)
 
         self._states = self._states[batch_size:]
+        self._actions = self._actions[batch_size:]
         self._next_states = self._next_states[batch_size:]
         self._rewards = self._rewards[batch_size:]
         self._lengths = self._lengths[batch_size:]
 
-        return states, next_states, rewards, lengths
+        return states, actions, next_states, rewards, lengths
 
 
-    def _store(self, state, reward, next_state, length):
+    def _store(self, state, action, reward, next_state, length):
         self._states.append(state)
+        self._actions.append(action)
         self._rewards.append(reward)
         self._next_states.append(next_state)
         self._lengths.append(length)

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -56,7 +56,7 @@ class NStepBuffer():
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)
         lengths = self._lengths[0:batch_size]
-        lengths = torch.tensor(lengths, device=rewards[0].device, dtype=torch.float)
+        lengths = torch.tensor(lengths, device=rewards[0].device)
 
         self._states = self._states[batch_size:]
         self._next_states = self._next_states[batch_size:]

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -28,14 +28,14 @@ class NStepBuffer():
                     last_state = states[i]
                     self._store(state, reward, last_state, length + 1)
             self._temp = self._temp[1:]
-        
+
         for t, _temp in enumerate(self._temp):
             discount = self.gamma ** (len(self._temp) - 1 - t)
             for i, v in enumerate(_temp):
                 state, reward, last_state, length = v
                 if last_state is not None:
                     reward += discount * rewards[i]
-                    last_state = last_state
+                    last_state = states[i]
                     length += 1
                 _temp[i] = (state, reward, last_state, length)
 
@@ -55,7 +55,7 @@ class NStepBuffer():
         next_states = self._next_states[0:batch_size]
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)
-        lengths = self._lengths[0:batch_size] # TODO
+        lengths = self._lengths[0:batch_size]
         lengths = torch.tensor(lengths, device=rewards[0].device)
 
         self._states = self._states[batch_size:]

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -2,63 +2,67 @@ import torch
 
 
 class NStepBuffer():
-    def __init__(self, n, buffer_length, discount_factor=1):
+    def __init__(self, n, discount_factor=1):
         self.n = n
-        self.buffer_length = buffer_length
         self.gamma = discount_factor
         self.i = 0
-        self.states = []
-        self.rewards = []
+        self._states = []
+        self._rewards = []
+        self._next_states = []
+        self._temp = []
+
+    def __len__(self):
+        return len(self._states)
 
     def store(self, states, rewards):
-        if self.i == 0:
-            self.states = [states]
-            self.rewards = [rewards]
-            self.i = 1
-            # do one thing
-        elif self.i <= self.buffer_length:
-            self.states.append(states)
-            self.rewards.append(rewards)
-            self.i += 1
-        else:
-            raise Exception("Buffer length exceeded: " + self.n)
+        # move states that are ready out of temp buffer
+        if len(self._temp) == self.n:
+            discount = self.gamma ** (self.n - 1)
+            for i, v in enumerate(self._temp[0]):
+                state, reward, last_state = v
+                if last_state is None:
+                    self._store(state, reward, last_state)
+                else:
+                    reward += discount * rewards[i]
+                    last_state = states[i]
+                    self._store(state, reward, last_state)
+            self._temp = self._temp[1:]
+        
+        for t, _temp in enumerate(self._temp):
+            discount = self.gamma ** (len(self._temp) - 1 - t)
+            for i, v in enumerate(_temp):
+                state, reward, last_state = v
+                if last_state is not None:
+                    reward += discount * rewards[i]
+                    last_state = last_state
+                _temp[i] = (state, reward, last_state)
 
-    def sample(self, _):
-        if self.i <= self.buffer_length:
-            raise Exception("Not enough states received!")
+        self._temp.append([
+            (state, reward, next_state)
+            for state, reward, next_state
+            in zip(states, rewards * 0, states)
+        ])
 
-        n_envs = len(self.states[0])
-        sample_n = n_envs * self.buffer_length
-        sample_states = [None] * sample_n
-        sample_next_states = [None] * sample_n
-        sample_returns = torch.zeros(sample_n, device=self.rewards[0].device)
-        sample_lengths = torch.zeros(sample_n, device=self.rewards[0].device)
+        return self
 
-        # compute the N-step returns the slow way
-        for e in range(n_envs):
-            for t in range(self.buffer_length):
-                i = t * n_envs + e
-                state = self.states[t][e]
-                returns = 0.
-                next_state = None
-                sample_length = 0
-                if state is not None:
-                    for k in range(1, self.n + 1):
-                        sample_length = k
-                        next_state = self.states[t + k][e]
-                        returns += (self.gamma ** (k - 1)) * \
-                            self.rewards[t + k][e]
-                        if next_state is None or t + k == self.buffer_length:
-                            break
-                sample_states[i] = state
-                sample_next_states[i] = next_state
-                sample_returns[i] = returns
-                sample_lengths[i] = sample_length
+    def sample(self, batch_size):
+        if batch_size > len(self):
+            raise Exception("Not enough states for batch size!")
 
-        self.states = [self.states[-1]]
-        self.rewards = [self.rewards[-1]]
-        self.i = 1
-        return (sample_states, sample_next_states, sample_returns, sample_lengths)
+        states = self._states[0:batch_size]
+        next_states = self._next_states[0:batch_size]
+        rewards = self._rewards[0:batch_size]
+        rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)
+        lengths = rewards # TODO
 
-    def is_full(self):
-        return self.i == self.buffer_length + 1
+        self._states = self._states[batch_size:]
+        self._next_states = self._next_states[batch_size:]
+        self._rewards = self._rewards[batch_size:]
+
+        return states, next_states, rewards, rewards
+
+
+    def _store(self, state, reward, next_state):
+        self._states.append(state)
+        self._rewards.append(reward)
+        self._next_states.append(next_state)

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -19,22 +19,23 @@ class NStepBuffer():
         if len(self._temp) == self.n:
             discount = self.gamma ** (self.n - 1)
             for i, v in enumerate(self._temp[0]):
-                state, reward, last_state = v
+                state, reward, last_state, length = v
                 if last_state is None:
-                    self._store(state, reward, last_state)
+                    self._store(state, reward, last_state, length)
                 else:
                     reward += discount * rewards[i]
                     last_state = states[i]
-                    self._store(state, reward, last_state)
+                    self._store(state, reward, last_state, length + 1)
             self._temp = self._temp[1:]
         
         for t, _temp in enumerate(self._temp):
             discount = self.gamma ** (len(self._temp) - 1 - t)
             for i, v in enumerate(_temp):
-                state, reward, last_state = v
+                state, reward, last_state, length = v
                 if last_state is not None:
                     reward += discount * rewards[i]
                     last_state = last_state
+                    length += 1
                 _temp[i] = (state, reward, last_state)
 
         self._temp.append([

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -68,29 +68,30 @@ class NStepBufferTest(unittest.TestCase):
     def test_multi_rollout(self):
         buffer = NStepBuffer(2, discount_factor=0.5)
         raw_states = ['state' + str(i) for i in range(12)]
-        expected_lengths = torch.tensor([2, 2, 1, 1])
+        expected_lengths = torch.tensor([2, 2, 2, 2])
         buffer.store(raw_states[0:2], torch.ones(2))
         buffer.store(raw_states[2:4], torch.ones(2))
         buffer.store(raw_states[4:6], torch.ones(2))
+        buffer.store(raw_states[6:8], torch.ones(2) * 2)
 
-        states, next_states, returns, lengths = buffer.sample(-1)
+        states, next_states, returns, lengths = buffer.sample(4)
         self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
         self.assert_array_equal(next_states, [
-            'state4', 'state5', 'state4', 'state5'
+            'state4', 'state5', 'state6', 'state7'
         ])
-        tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+        tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 2, 2]))
         tt.assert_equal(lengths, expected_lengths)
 
-        buffer.store(raw_states[6:8], torch.ones(2))
         buffer.store(raw_states[8:10], torch.ones(2))
+        buffer.store(raw_states[10:12], torch.ones(2))
 
-        states, next_states, returns, lengths = buffer.sample(-1)
+        states, next_states, returns, lengths = buffer.sample(4)
         self.assert_array_equal(
             states, ['state' + str(i) for i in range(4, 8)])
         self.assert_array_equal(next_states, [
-            'state8', 'state9', 'state8', 'state9'
+            'state8', 'state9', 'state10', 'state11'
         ])
-        tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+        tt.assert_allclose(returns, torch.tensor([2.5, 2.5, 1.5, 1.5]))
         tt.assert_equal(lengths, expected_lengths)
 
     def assert_array_equal(self, actual, expected):

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -6,32 +6,26 @@ from all.memory import NStepBuffer
 
 class NStepBufferTest(unittest.TestCase):
     def test_rollout(self):
-        buffer = NStepBuffer(2, 3, discount_factor=0.5)
+        buffer = NStepBuffer(2, discount_factor=0.5)
         buffer.store(['state1', 'state2', 'state3'], torch.zeros(3))
         buffer.store(['state4', 'state5', 'state6'], torch.ones(3))
         buffer.store(['state7', 'state8', 'state9'], 2 * torch.ones(3))
         buffer.store(['state10', 'state11', 'state12'], 4 * torch.ones(3))
-        states, next_states, returns, lengths = buffer.sample(-1)
+        self.assertEqual(len(buffer), 6)
 
-        expected_states = ['state' + str(i + 1) for i in range(9)]
-        expect_next_states = [
-            'state7', 'state8', 'state9',
-            'state10', 'state11', 'state12',
-            'state10', 'state11', 'state12',
-        ]
+        states, next_states, returns, lengths = buffer.sample(6)
+        expected_states = ['state' + str(i) for i in range(1, 7)]
+        expected_next_states = ['state' + str(i) for i in range(7, 13)]
         expected_returns = torch.tensor([
             2, 2, 2,
             4, 4, 4,
-            4, 4, 4
         ]).float()
         expected_lengths = torch.tensor([
             2, 2, 2,
             2, 2, 2,
-            1, 1, 1
         ])
-
         self.assert_array_equal(states, expected_states)
-        self.assert_array_equal(next_states, expect_next_states)
+        self.assert_array_equal(next_states, expected_next_states)
         tt.assert_allclose(returns, expected_returns)
         tt.assert_equal(lengths, expected_lengths)
 

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -30,36 +30,34 @@ class NStepBufferTest(unittest.TestCase):
         tt.assert_equal(lengths, expected_lengths)
 
     def test_rollout_with_nones(self):
-        buffer = NStepBuffer(3, 3, discount_factor=0.5)
+        buffer = NStepBuffer(3, discount_factor=0.5)
         states = [
             ['state1', 'state2', 'state3'],
             ['state4', 'state5', None],
             ['state7', None, 'state9'],
-            [None, 'state11', 'state12']
+            [None, 'state11', 'state12'],
+            ['state13', 'state14', 'state15']
         ]
         buffer.store(states[0], torch.zeros(3))
         buffer.store(states[1], torch.ones(3))
         buffer.store(states[2], 2 * torch.ones(3))
         buffer.store(states[3], 4 * torch.ones(3))
-        states, next_states, returns, lengths = buffer.sample(-1)
+        buffer.store(states[4], 8 * torch.ones(3))
+        states, next_states, returns, lengths = buffer.sample(6)
 
-        expected_states = ['state' + str(i + 1) for i in range(9)]
+        expected_states = ['state' + str(i + 1) for i in range(6)]
         expected_states[5] = None
-        expected_states[7] = None
         expect_next_states = [
             None, None, None,
             None, None, None,
-            None, None, 'state12',
         ]
         expected_returns = torch.tensor([
             3, 2, 1,
             4, 2, 0,
-            4, 0, 4
         ]).float()
         expected_lengths = torch.tensor([
             3, 2, 1,
             2, 1, 0,
-            1, 0, 1
         ])
 
         self.assert_array_equal(states, expected_states)
@@ -68,7 +66,7 @@ class NStepBufferTest(unittest.TestCase):
         tt.assert_equal(lengths, expected_lengths)
 
     def test_multi_rollout(self):
-        buffer = NStepBuffer(2, 2, discount_factor=0.5)
+        buffer = NStepBuffer(2, discount_factor=0.5)
         raw_states = ['state' + str(i) for i in range(12)]
         expected_lengths = torch.tensor([2, 2, 1, 1])
         buffer.store(raw_states[0:2], torch.ones(2))

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -7,13 +7,14 @@ from all.memory import NStepBuffer
 class NStepBufferTest(unittest.TestCase):
     def test_rollout(self):
         buffer = NStepBuffer(2, discount_factor=0.5)
-        buffer.store(['state1', 'state2', 'state3'], torch.zeros(3))
-        buffer.store(['state4', 'state5', 'state6'], torch.ones(3))
-        buffer.store(['state7', 'state8', 'state9'], 2 * torch.ones(3))
-        buffer.store(['state10', 'state11', 'state12'], 4 * torch.ones(3))
+        actions = torch.ones((3))
+        buffer.store(['state1', 'state2', 'state3'], actions, torch.zeros(3))
+        buffer.store(['state4', 'state5', 'state6'], actions, torch.ones(3))
+        buffer.store(['state7', 'state8', 'state9'], actions, 2 * torch.ones(3))
+        buffer.store(['state10', 'state11', 'state12'], actions, 4 * torch.ones(3))
         self.assertEqual(len(buffer), 6)
 
-        states, next_states, returns, lengths = buffer.sample(6)
+        states, actions, next_states, returns, lengths = buffer.sample(6)
         expected_states = ['state' + str(i) for i in range(1, 7)]
         expected_next_states = ['state' + str(i) for i in range(7, 13)]
         expected_returns = torch.tensor([
@@ -38,12 +39,13 @@ class NStepBufferTest(unittest.TestCase):
             [None, 'state11', 'state12'],
             ['state13', 'state14', 'state15']
         ]
-        buffer.store(states[0], torch.zeros(3))
-        buffer.store(states[1], torch.ones(3))
-        buffer.store(states[2], 2 * torch.ones(3))
-        buffer.store(states[3], 4 * torch.ones(3))
-        buffer.store(states[4], 8 * torch.ones(3))
-        states, next_states, returns, lengths = buffer.sample(6)
+        actions = torch.ones((3))
+        buffer.store(states[0], actions, torch.zeros(3))
+        buffer.store(states[1], actions, torch.ones(3))
+        buffer.store(states[2], actions, 2 * torch.ones(3))
+        buffer.store(states[3], actions, 4 * torch.ones(3))
+        buffer.store(states[4], actions, 8 * torch.ones(3))
+        states, actions, next_states, returns, lengths = buffer.sample(6)
 
         expected_states = ['state' + str(i + 1) for i in range(6)]
         expected_states[5] = None
@@ -69,12 +71,13 @@ class NStepBufferTest(unittest.TestCase):
         buffer = NStepBuffer(2, discount_factor=0.5)
         raw_states = ['state' + str(i) for i in range(12)]
         expected_lengths = torch.tensor([2, 2, 2, 2])
-        buffer.store(raw_states[0:2], torch.ones(2))
-        buffer.store(raw_states[2:4], torch.ones(2))
-        buffer.store(raw_states[4:6], torch.ones(2))
-        buffer.store(raw_states[6:8], torch.ones(2) * 2)
+        actions = torch.ones(2)
+        buffer.store(raw_states[0:2], actions, torch.ones(2))
+        buffer.store(raw_states[2:4], actions, torch.ones(2))
+        buffer.store(raw_states[4:6], actions, torch.ones(2))
+        buffer.store(raw_states[6:8], actions, torch.ones(2) * 2)
 
-        states, next_states, returns, lengths = buffer.sample(4)
+        states, actions, next_states, returns, lengths = buffer.sample(4)
         self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
         self.assert_array_equal(next_states, [
             'state4', 'state5', 'state6', 'state7'
@@ -82,10 +85,10 @@ class NStepBufferTest(unittest.TestCase):
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 2, 2]))
         tt.assert_equal(lengths, expected_lengths)
 
-        buffer.store(raw_states[8:10], torch.ones(2))
-        buffer.store(raw_states[10:12], torch.ones(2))
+        buffer.store(raw_states[8:10], actions, torch.ones(2))
+        buffer.store(raw_states[10:12], actions, torch.ones(2))
 
-        states, next_states, returns, lengths = buffer.sample(4)
+        states, actions, next_states, returns, lengths = buffer.sample(4)
         self.assert_array_equal(
             states, ['state' + str(i) for i in range(4, 8)])
         self.assert_array_equal(next_states, [

--- a/all/policies/softmax.py
+++ b/all/policies/softmax.py
@@ -1,11 +1,11 @@
-import torch
-from torch.nn import functional, utils
-from all.layers import ListNetwork
-from tensorboardX import SummaryWriter
-from .abstract import Policy
-
 import os
 from datetime import datetime
+import torch
+from torch.nn import functional, utils
+from tensorboardX import SummaryWriter
+from all.layers import ListNetwork
+from .abstract import Policy
+
 
 class SoftmaxPolicy(Policy):
     def __init__(self, model, optimizer, actions, entropy_loss_scaling=0, clip_grad=0):
@@ -71,7 +71,7 @@ class SoftmaxPolicy(Policy):
             i += 1
         if items != batch_size:
             raise ValueError("Incompatible batch size: " + str(batch_size))
-        
+
         log_probs = torch.cat(self._log_probs[:i])
         self._log_probs = self._log_probs[i:]
         entropy = torch.cat(self._entropy[:i])

--- a/all/policies/softmax.py
+++ b/all/policies/softmax.py
@@ -55,7 +55,7 @@ class SoftmaxPolicy(Policy):
             items += len(self._log_probs[i])
             i += 1
         if items != batch_size:
-            raise ValueError("Incompatible batch size.")
+            raise ValueError("Incompatible batch size: " + str(batch_size))
         
         log_probs = torch.cat(self._log_probs[:i])
         self._log_probs = self._log_probs[i:]

--- a/all/policies/softmax_test.py
+++ b/all/policies/softmax_test.py
@@ -33,6 +33,15 @@ class TestSoftmax(unittest.TestCase):
         tt.assert_equal(actions, torch.tensor([2, 2, 0]))
         self.policy.reinforce(torch.tensor([[1, 2, 3]]).float())
 
+    def test_multi_batch_reinforce(self):
+        states = torch.randn(10, STATE_DIM)
+        self.policy(states)
+        self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+        self.policy.reinforce(torch.tensor([1, 2, 3, 4]).float())
+        self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+        with self.assertRaises(Exception):
+            self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+
     def test_list(self):
         torch.manual_seed(1)
         states = [

--- a/all/policies/softmax_test.py
+++ b/all/policies/softmax_test.py
@@ -53,5 +53,17 @@ class TestSoftmax(unittest.TestCase):
         tt.assert_equal(actions, torch.tensor([2, 0, 1]))
         self.policy.reinforce(torch.tensor([[1, 2, 3]]).float())
 
+    def test_action_prob(self):
+        torch.manual_seed(1)
+        states = [
+            torch.randn(1, STATE_DIM),
+            None,
+            torch.randn(1, STATE_DIM)
+        ]
+        with torch.no_grad():
+            actions = self.policy(states)
+        probs = self.policy(states, action=actions)
+        tt.assert_almost_equal(probs, torch.tensor([0.4814, 0.3333, 0.2049]), decimal=3)
+
 if __name__ == '__main__':
     unittest.main()

--- a/all/policies/softmax_test.py
+++ b/all/policies/softmax_test.py
@@ -34,13 +34,13 @@ class TestSoftmax(unittest.TestCase):
         self.policy.reinforce(torch.tensor([[1, 2, 3]]).float())
 
     def test_multi_batch_reinforce(self):
-        states = torch.randn(10, STATE_DIM)
-        self.policy(states)
-        self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+        self.policy(torch.randn(2, STATE_DIM))
+        self.policy(torch.randn(2, STATE_DIM))
+        self.policy(torch.randn(2, STATE_DIM))
         self.policy.reinforce(torch.tensor([1, 2, 3, 4]).float())
-        self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+        self.policy.reinforce(torch.tensor([1, 2]).float())
         with self.assertRaises(Exception):
-            self.policy.reinforce(torch.tensor([1, 2, 3]).float())
+            self.policy.reinforce(torch.tensor([1, 2]).float())
 
     def test_list(self):
         torch.manual_seed(1)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -2,6 +2,7 @@
 import torch
 from torch import nn
 from torch.optim import Adam
+from torch.nn.functional import smooth_l1_loss
 from all.layers import Flatten, Linear0
 from all.agents import A2C
 from all.bodies import ParallelAtariBody
@@ -42,10 +43,10 @@ def a2c(
         discount_factor=0.99,
         entropy_loss_scaling=0.01,
         eps=1.5e-4,  # Adam epsilon
-        lr=1e-3,
-        n_envs=50,
-        n_steps=5,
-        update_frequency=5,
+        lr=1e-4,
+        n_envs=16,
+        n_steps=16,
+        update_frequency=16,
         device=torch.device('cpu')
 ):
     def _a2c(envs):
@@ -60,7 +61,12 @@ def a2c(
 
         features = FeatureNetwork(
             feature_model, feature_optimizer, clip_grad=clip_grad)
-        v = ValueNetwork(value_model, value_optimizer, clip_grad=clip_grad)
+        v = ValueNetwork(
+            value_model,
+            value_optimizer,
+            clip_grad=clip_grad,
+            loss=smooth_l1_loss
+        )
         policy = SoftmaxPolicy(
             policy_model,
             policy_optimizer,

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -43,10 +43,10 @@ def a2c(
         discount_factor=0.99,
         entropy_loss_scaling=0.01,
         eps=1.5e-4,  # Adam epsilon
-        lr=1e-4,
-        n_envs=16,
-        n_steps=16,
-        update_frequency=16,
+        lr=1e-3,
+        n_envs=50,
+        n_steps=4,
+        update_frequency=2,
         device=torch.device('cpu')
 ):
     def _a2c(envs):

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -24,7 +24,7 @@ def a2c(
         lr=1e-3,
         n_envs=8,
         n_steps=8,
-        batch_size=30,
+        update_frequency=8,
 ):
     def _a2c(envs):
         env = envs[0]
@@ -50,7 +50,7 @@ def a2c(
             v,
             policy,
             n_steps=n_steps,
-            batch_size=batch_size,
+            update_frequency=update_frequency,
             discount_factor=discount_factor
         )
     return _a2c, n_envs

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -21,7 +21,7 @@ def a2c(
         clip_grad=0.1,
         discount_factor=0.99,
         entropy_loss_scaling=0.001,
-        lr=1e-3,
+        lr=3e-4,
         n_envs=8,
         n_steps=8,
         update_frequency=8,

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -24,7 +24,7 @@ def a2c(
         lr=1e-3,
         n_envs=8,
         n_steps=8,
-        update_frequency=8,
+        batch_size=30,
 ):
     def _a2c(envs):
         env = envs[0]
@@ -50,7 +50,7 @@ def a2c(
             v,
             policy,
             n_steps=n_steps,
-            update_frequency=update_frequency,
+            batch_size=batch_size,
             discount_factor=discount_factor
         )
     return _a2c, n_envs

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -20,7 +20,7 @@ def fc_policy(env):
 def a2c(
         clip_grad=0.1,
         discount_factor=0.99,
-        entropy_loss_scaling=0.01,
+        entropy_loss_scaling=0.001,
         lr=1e-3,
         n_envs=8,
         n_steps=8,

--- a/benchmarks/atari.py
+++ b/benchmarks/atari.py
@@ -6,8 +6,14 @@ from runner import run
 def run_atari():
     parser = argparse.ArgumentParser(description='Run an Atari benchmark.')
     parser.add_argument('env', help='Name of the Atari game (e.g. Pong)')
-    parser.add_argument('agent', help="Name of the agent (e.g. dqn). See presets for available agents.")
-    parser.add_argument('device', default='cpu', help='The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)')
+    parser.add_argument(
+        'agent',
+        help="Name of the agent (e.g. dqn). See presets for available agents."
+    )
+    parser.add_argument(
+        'device', default='cpu',
+        help='The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)'
+    )
     parser.add_argument('--frames', type=int, default=100e6, help='The number of training frames')
     args = parser.parse_args()
 


### PR DESCRIPTION
A fully working version of a2c! Learns pong in ~20 million frames, which is not great, but is a good start.

The `NStepBuffer` was refactor to be a "double buffer": The first buffer stores incomplete rollouts. Once the rollouts are completed, they are moved to the inner buffer. From there, they can be sampled. The implementation is somewhat inefficient, as it requires an n^2 for loop to compute the discounted rewards.

The Policy and Value Network classes were tweaked to enable partial training on the cache: that is, If they have cached 12 time steps worth of forward passes, you could train the first 5 and save the remaining 7 for later. The only catch is that you are required to train each full forward pass in the same batch.