### PR TITLE
Feature/on policy a2c

### DIFF
--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -1,4 +1,5 @@
-from all.memory import NStepBatchBuffer, NStepBuffer
+import torch
+from all.memory import NStepBuffer
 from .abstract import Agent
 
 
@@ -26,7 +27,7 @@ class A2C(Agent):
     def act(self, states, rewards, info=None):
         # store transition and train BEFORE choosing action
         # Do not need to know actions, so pass in empy array
-        self._buffer.store(states, [None] * self.n_envs, rewards)
+        self._buffer.store(states, torch.zeros(self.n_envs), rewards)
         while len(self._buffer) >= self._batch_size:
             self._train()
         return self.policy(self.features(states))

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -1,5 +1,5 @@
 import torch
-from all.memory import NStepBuffer
+from all.memory import NStepBatchBuffer
 from .abstract import Agent
 
 
@@ -45,7 +45,8 @@ class A2C(Agent):
         self.features.reinforce()
 
     def _make_buffer(self):
-        return NStepBuffer(
+        return NStepBatchBuffer(
             self.n_steps,
+            self.n_envs,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -1,4 +1,4 @@
-from all.memory import NStepBuffer
+from all.memory import NStepBatchBuffer
 from .abstract import Agent
 
 
@@ -8,6 +8,7 @@ class A2C(Agent):
             features,
             v,
             policy,
+            n_envs=1,
             n_steps=4,
             update_frequency=4,
             discount_factor=0.99
@@ -15,21 +16,23 @@ class A2C(Agent):
         self.features = features
         self.v = v
         self.policy = policy
+        self.n_envs = n_envs
         self.n_steps = n_steps
         self.update_frequency = update_frequency
         self.discount_factor = discount_factor
+        self._batch_size = n_envs * n_steps
         self._buffer = self._make_buffer()
 
     def act(self, states, rewards, info=None):
         batch_size = len(states) * self.update_frequency
         while len(self._buffer) >= batch_size:
             self._train(batch_size)
-        actions = self.policy.eval(self.features(states))
-        self._buffer.store(states, actions, rewards)
+        actions = self.policy(self.features(states))
+        self._buffer.store(states, rewards)
         return actions
 
     def _train(self, batch_size):
-        states, actions, next_states, returns, rollout_lengths = self._buffer.sample(batch_size)
+        states, next_states, returns, rollout_lengths = self._buffer.sample(batch_size)
         features = self.features(states)
         next_features = self.features(next_states)
         td_errors = (
@@ -39,12 +42,12 @@ class A2C(Agent):
             - self.v(features)
         )
         self.v.reinforce(td_errors, retain_graph=True)
-        self.policy(features, action=actions)
         self.policy.reinforce(td_errors)
         self.features.reinforce()
 
     def _make_buffer(self):
-        return NStepBuffer(
+        return NStepBatchBuffer(
             self.n_steps,
+            self.n_envs,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -10,7 +10,6 @@ class A2C(Agent):
             policy,
             n_envs=1,
             n_steps=4,
-            update_frequency=4,
             discount_factor=0.99
     ):
         self.features = features
@@ -18,21 +17,19 @@ class A2C(Agent):
         self.policy = policy
         self.n_envs = n_envs
         self.n_steps = n_steps
-        self.update_frequency = update_frequency
         self.discount_factor = discount_factor
         self._batch_size = n_envs * n_steps
         self._buffer = self._make_buffer()
 
     def act(self, states, rewards, info=None):
-        batch_size = len(states) * self.update_frequency
-        while len(self._buffer) >= batch_size:
-            self._train(batch_size)
+        while len(self._buffer) >= self._batch_size:
+            self._train()
         actions = self.policy(self.features(states))
         self._buffer.store(states, rewards)
         return actions
 
-    def _train(self, batch_size):
-        states, next_states, returns, rollout_lengths = self._buffer.sample(batch_size)
+    def _train(self):
+        states, next_states, returns, rollout_lengths = self._buffer.sample(self._batch_size)
         features = self.features(states)
         next_features = self.features(next_states)
         td_errors = (

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -1,4 +1,4 @@
-from all.memory import NStepBatchBuffer
+from all.memory import NStepBatchBuffer, NStepBuffer
 from .abstract import Agent
 
 
@@ -44,8 +44,7 @@ class A2C(Agent):
         self.features.reinforce()
 
     def _make_buffer(self):
-        return NStepBatchBuffer(
+        return NStepBuffer(
             self.n_steps,
-            self.n_envs,
             discount_factor=self.discount_factor
         )

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -25,11 +25,11 @@ class A2C(Agent):
         while len(self._buffer) >= self._batch_size:
             self._train()
         actions = self.policy(self.features(states))
-        self._buffer.store(states, rewards)
+        self._buffer.store(states, actions, rewards)
         return actions
 
     def _train(self):
-        states, next_states, returns, rollout_lengths = self._buffer.sample(self._batch_size)
+        states, _, next_states, returns, rollout_lengths = self._buffer.sample(self._batch_size)
         features = self.features(states)
         next_features = self.features(next_states)
         td_errors = (

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -8,10 +8,12 @@ class A2C(Agent):
             features,
             v,
             policy,
-            n_envs=1,
+            n_envs=None,
             n_steps=4,
             discount_factor=0.99
     ):
+        if n_envs is None:
+            raise RuntimeError("Must specify n_envs.")
         self.features = features
         self.v = v
         self.policy = policy

--- a/all/memory/__init__.py
+++ b/all/memory/__init__.py
@@ -1,9 +1,10 @@
 from .replay_buffer import ReplayBuffer, ExperienceReplayBuffer, PrioritizedReplayBuffer
-from .n_step import NStepBuffer
+from .n_step import NStepBuffer, NStepBatchBuffer
 
 __all__ = [
     "ReplayBuffer",
     "ExperienceReplayBuffer",
     "PrioritizedReplayBuffer",
     "NStepBuffer",
+    "NStepBatchBuffer"
 ]

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -2,6 +2,7 @@ import torch
 
 
 class NStepBuffer():
+    '''A rolling n-step buffer, such that every sample is an n-step rollout.'''
     def __init__(self, n, discount_factor=1):
         self.n = n
         self.gamma = discount_factor
@@ -76,3 +77,64 @@ class NStepBuffer():
         self._rewards.append(reward)
         self._next_states.append(next_state)
         self._lengths.append(length)
+
+class NStepBatchBuffer():
+    '''
+    A batch version of the n-step buffer, such that the first sample is n-step, second is n-1-step, etc.
+    This may be better for on-policy methods.
+    '''
+    def __init__(self, n, batch_size, discount_factor=1):
+        self.n = n
+        self.batch_size = batch_size
+        self.gamma = discount_factor
+        self.i = 0
+        self._states = []
+        self._rewards = []
+
+    def __len__(self):
+        return len(self._states)
+
+    def store(self, states, rewards):
+        if self.i == 0:
+            self._states = [states]
+            self._rewards = [rewards]
+            self.i = 1
+        elif self.i <= self.batch_size:
+            self._states.append(states)
+            self._rewards.append(rewards)
+            self.i += 1
+        else:
+            raise Exception("Buffer length exceeded: " + self.n)
+
+    def sample(self, _):
+        if self.i <= self.batch_size:
+            raise Exception("Not enough states received!")
+
+        n_envs = len(self._states[0])
+        sample_n = n_envs * self.batch_size
+        sample_states = [None] * sample_n
+        sample_next_states = [None] * sample_n
+        sample_returns = torch.zeros(sample_n, device=self._rewards[0].device)
+
+        # compute the N-step returns the slow way
+        for e in range(n_envs):
+            for t in range(self.batch_size):
+                i = t * n_envs + e
+                state = self._states[t][e]
+                returns = 0.
+                next_state = None
+                if state is not None:
+                    for k in range(1, self.n + 1):
+                        next_state = self._states[t + k][e]
+                        returns += (self.gamma ** (k - 1)) * \
+                            self._rewards[t + k][e]
+                        if next_state is None or t + k == self.batch_size:
+                            break
+                sample_states[i] = state
+                sample_next_states[i] = next_state
+                sample_returns[i] = returns
+
+        self._states = [self._states[-1]]
+        self._rewards = [self._rewards[-1]]
+        self.i = 1
+        return (sample_states, sample_next_states, sample_returns)

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -59,7 +59,7 @@ class NStepBuffer:
 
         states = self._states[0:batch_size]
         actions = self._actions[0:batch_size]
-        actions = torch.tensor(actions, device=actions[0].device)
+        # actions = torch.tensor(actions, device=actions[0].device)
         next_states = self._next_states[0:batch_size]
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -59,7 +59,7 @@ class NStepBuffer:
 
         states = self._states[0:batch_size]
         actions = self._actions[0:batch_size]
-        # actions = torch.tensor(actions, device=actions[0].device)
+        actions = torch.tensor(actions, device=actions[0].device)
         next_states = self._next_states[0:batch_size]
         rewards = self._rewards[0:batch_size]
         rewards = torch.tensor(rewards, device=rewards[0].device, dtype=torch.float)

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -107,25 +107,27 @@ class NStepBatchBufferTest(unittest.TestCase):
         buffer = NStepBatchBuffer(2, 3, discount_factor=0.5)
         buffer.store(['state1', 'state2', 'state3'], torch.zeros(3))
         buffer.store(['state4', 'state5', 'state6'], torch.ones(3))
-        buffer.store(['state7', 'state8', 'state9'], 2 * torch.ones(3))
-        buffer.store(['state10', 'state11', 'state12'], 4 * torch.ones(3))
-        states, next_states, returns = buffer.sample(-1)
+        buffer.store(['state7', 'state8', 'state9'], 4 * torch.ones(3))
+        states, next_states, returns, lengths = buffer.sample(-1)
 
-        expected_states = ['state' + str(i + 1) for i in range(9)]
+        expected_states = ['state' + str(i + 1) for i in range(6)]
         expect_next_states = [
             'state7', 'state8', 'state9',
-            'state10', 'state11', 'state12',
-            'state10', 'state11', 'state12',
+            'state7', 'state8', 'state9',
         ]
         expected_returns = torch.tensor([
-            2, 2, 2,
-            4, 4, 4,
+            3, 3, 3,
             4, 4, 4
         ]).float()
+        expected_lengths = torch.tensor([
+            2, 2, 2,
+            1, 1, 1
+        ]).long()
 
         self.assert_array_equal(states, expected_states)
         self.assert_array_equal(next_states, expect_next_states)
         tt.assert_allclose(returns, expected_returns)
+        tt.assert_equal(lengths, expected_lengths)
 
     def test_rollout_with_nones(self):
         buffer = NStepBatchBuffer(3, 3, discount_factor=0.5)
@@ -139,7 +141,7 @@ class NStepBatchBufferTest(unittest.TestCase):
         buffer.store(states[1], torch.ones(3))
         buffer.store(states[2], 2 * torch.ones(3))
         buffer.store(states[3], 4 * torch.ones(3))
-        states, next_states, returns = buffer.sample(-1)
+        states, next_states, returns, lengths = buffer.sample(-1)
 
         expected_states = ['state' + str(i + 1) for i in range(9)]
         expected_states[5] = None
@@ -154,10 +156,16 @@ class NStepBatchBufferTest(unittest.TestCase):
             4, 2, 0,
             4, 0, 4
         ]).float()
+        expected_lengths = torch.tensor([
+            3, 2, 1,
+            2, 1, 0,
+            1, 0, 1
+        ]).float()
 
         self.assert_array_equal(states, expected_states)
         self.assert_array_equal(next_states, expect_next_states)
         tt.assert_allclose(returns, expected_returns)
+        tt.assert_equal(lengths, expected_lengths)
 
     def test_multi_rollout(self):
         buffer = NStepBatchBuffer(2, 2, discount_factor=0.5)
@@ -166,23 +174,25 @@ class NStepBatchBufferTest(unittest.TestCase):
         buffer.store(raw_states[2:4], torch.ones(2))
         buffer.store(raw_states[4:6], torch.ones(2))
 
-        states, next_states, returns = buffer.sample(-1)
+        states, next_states, returns, lengths = buffer.sample(-1)
         self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
         self.assert_array_equal(next_states, [
             'state4', 'state5', 'state4', 'state5'
         ])
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+        tt.assert_equal(lengths, torch.tensor([2, 2, 1, 1]))
 
         buffer.store(raw_states[6:8], torch.ones(2))
         buffer.store(raw_states[8:10], torch.ones(2))
 
-        states, next_states, returns = buffer.sample(-1)
+        states, next_states, returns, lengths = buffer.sample(-1)
         self.assert_array_equal(
             states, ['state' + str(i) for i in range(4, 8)])
         self.assert_array_equal(next_states, [
             'state8', 'state9', 'state8', 'state9'
         ])
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+        tt.assert_equal(lengths, torch.tensor([2, 2, 1, 1]))
 
     def assert_array_equal(self, actual, expected):
         for i, exp in enumerate(expected):

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -105,10 +105,11 @@ class NStepBufferTest(unittest.TestCase):
 class NStepBatchBufferTest(unittest.TestCase):
     def test_rollout(self):
         buffer = NStepBatchBuffer(2, 3, discount_factor=0.5)
-        buffer.store(['state1', 'state2', 'state3'], torch.zeros(3))
-        buffer.store(['state4', 'state5', 'state6'], torch.ones(3))
-        buffer.store(['state7', 'state8', 'state9'], 4 * torch.ones(3))
-        states, next_states, returns, lengths = buffer.sample(-1)
+        actions = torch.ones((3))
+        buffer.store(['state1', 'state2', 'state3'], actions, torch.zeros(3))
+        buffer.store(['state4', 'state5', 'state6'], actions, torch.ones(3))
+        buffer.store(['state7', 'state8', 'state9'], actions, 4 * torch.ones(3))
+        states, _, next_states, returns, lengths = buffer.sample(-1)
 
         expected_states = ['state' + str(i + 1) for i in range(6)]
         expect_next_states = [
@@ -137,11 +138,12 @@ class NStepBatchBufferTest(unittest.TestCase):
             ['state7', None, 'state9'],
             [None, 'state11', 'state12']
         ]
-        buffer.store(states[0], torch.zeros(3))
-        buffer.store(states[1], torch.ones(3))
-        buffer.store(states[2], 2 * torch.ones(3))
-        buffer.store(states[3], 4 * torch.ones(3))
-        states, next_states, returns, lengths = buffer.sample(-1)
+        actions = torch.ones((3))
+        buffer.store(states[0], actions, torch.zeros(3))
+        buffer.store(states[1], actions, torch.ones(3))
+        buffer.store(states[2], actions, 2 * torch.ones(3))
+        buffer.store(states[3], actions, 4 * torch.ones(3))
+        states, actions, next_states, returns, lengths = buffer.sample(-1)
 
         expected_states = ['state' + str(i + 1) for i in range(9)]
         expected_states[5] = None
@@ -170,11 +172,12 @@ class NStepBatchBufferTest(unittest.TestCase):
     def test_multi_rollout(self):
         buffer = NStepBatchBuffer(2, 2, discount_factor=0.5)
         raw_states = ['state' + str(i) for i in range(12)]
-        buffer.store(raw_states[0:2], torch.ones(2))
-        buffer.store(raw_states[2:4], torch.ones(2))
-        buffer.store(raw_states[4:6], torch.ones(2))
+        actions = torch.ones((2))
+        buffer.store(raw_states[0:2], actions, torch.ones(2))
+        buffer.store(raw_states[2:4], actions, torch.ones(2))
+        buffer.store(raw_states[4:6], actions, torch.ones(2))
 
-        states, next_states, returns, lengths = buffer.sample(-1)
+        states, actions, next_states, returns, lengths = buffer.sample(-1)
         self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
         self.assert_array_equal(next_states, [
             'state4', 'state5', 'state4', 'state5'
@@ -182,10 +185,10 @@ class NStepBatchBufferTest(unittest.TestCase):
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
         tt.assert_equal(lengths, torch.tensor([2, 2, 1, 1]))
 
-        buffer.store(raw_states[6:8], torch.ones(2))
-        buffer.store(raw_states[8:10], torch.ones(2))
+        buffer.store(raw_states[6:8], actions, torch.ones(2))
+        buffer.store(raw_states[8:10], actions, torch.ones(2))
 
-        states, next_states, returns, lengths = buffer.sample(-1)
+        states, actions, next_states, returns, lengths = buffer.sample(-1)
         self.assert_array_equal(
             states, ['state' + str(i) for i in range(4, 8)])
         self.assert_array_equal(next_states, [

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 import torch_testing as tt
-from all.memory import NStepBuffer
+from all.memory import NStepBuffer, NStepBatchBuffer
 
 
 class NStepBufferTest(unittest.TestCase):
@@ -102,6 +102,96 @@ class NStepBufferTest(unittest.TestCase):
             self.assertEqual(actual[i], exp, msg=(
                 ("\nactual: %s\nexpected: %s") % (actual, expected)))
 
+class NStepBatchBufferTest(unittest.TestCase):
+    def test_rollout(self):
+        buffer = NStepBatchBuffer(2, 3, discount_factor=0.5)
+        buffer.store(['state1', 'state2', 'state3'], torch.zeros(3))
+        buffer.store(['state4', 'state5', 'state6'], torch.ones(3))
+        buffer.store(['state7', 'state8', 'state9'], 2 * torch.ones(3))
+        buffer.store(['state10', 'state11', 'state12'], 4 * torch.ones(3))
+        states, next_states, returns = buffer.sample(-1)
+
+        expected_states = ['state' + str(i + 1) for i in range(9)]
+        expect_next_states = [
+            'state7', 'state8', 'state9',
+            'state10', 'state11', 'state12',
+            'state10', 'state11', 'state12',
+        ]
+        expected_returns = torch.tensor([
+            2, 2, 2,
+            4, 4, 4,
+            4, 4, 4
+        ]).float()
+
+        self.assert_array_equal(states, expected_states)
+        self.assert_array_equal(next_states, expect_next_states)
+        tt.assert_allclose(returns, expected_returns)
+
+    def test_rollout_with_nones(self):
+        buffer = NStepBatchBuffer(3, 3, discount_factor=0.5)
+        states = [
+            ['state1', 'state2', 'state3'],
+            ['state4', 'state5', None],
+            ['state7', None, 'state9'],
+            [None, 'state11', 'state12']
+        ]
+        buffer.store(states[0], torch.zeros(3))
+        buffer.store(states[1], torch.ones(3))
+        buffer.store(states[2], 2 * torch.ones(3))
+        buffer.store(states[3], 4 * torch.ones(3))
+        states, next_states, returns = buffer.sample(-1)
+
+        expected_states = ['state' + str(i + 1) for i in range(9)]
+        expected_states[5] = None
+        expected_states[7] = None
+        expect_next_states = [
+            None, None, None,
+            None, None, None,
+            None, None, 'state12',
+        ]
+        expected_returns = torch.tensor([
+            3, 2, 1,
+            4, 2, 0,
+            4, 0, 4
+        ]).float()
+
+        self.assert_array_equal(states, expected_states)
+        self.assert_array_equal(next_states, expect_next_states)
+        tt.assert_allclose(returns, expected_returns)
+
+    def test_multi_rollout(self):
+        buffer = NStepBatchBuffer(2, 2, discount_factor=0.5)
+        raw_states = ['state' + str(i) for i in range(12)]
+        buffer.store(raw_states[0:2], torch.ones(2))
+        buffer.store(raw_states[2:4], torch.ones(2))
+        buffer.store(raw_states[4:6], torch.ones(2))
+
+        states, next_states, returns = buffer.sample(-1)
+        self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
+        self.assert_array_equal(next_states, [
+            'state4', 'state5', 'state4', 'state5'
+        ])
+        tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+
+        buffer.store(raw_states[6:8], torch.ones(2))
+        buffer.store(raw_states[8:10], torch.ones(2))
+
+        states, next_states, returns = buffer.sample(-1)
+        self.assert_array_equal(
+            states, ['state' + str(i) for i in range(4, 8)])
+        self.assert_array_equal(next_states, [
+            'state8', 'state9', 'state8', 'state9'
+        ])
+        tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
+
+    def assert_array_equal(self, actual, expected):
+        for i, exp in enumerate(expected):
+            self.assertEqual(actual[i], exp, msg=(
+                ("\nactual: %s\nexpected: %s") % (actual, expected)))
+
+
+if __name__ == '__main__':
+    unittest.main()
 
 if __name__ == '__main__':
     unittest.main()

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -18,37 +18,31 @@ def conv_features():
         nn.ReLU(),
         nn.Conv2d(64, 64, 3, stride=1),
         nn.ReLU(),
-        Flatten()
+        Flatten(),
     )
 
 
 def value_net():
-    return nn.Sequential(
-        nn.Linear(3456, 512),
-        nn.ReLU(),
-        Linear0(512, 1)
-    )
+    return nn.Sequential(nn.Linear(3456, 512), nn.ReLU(), Linear0(512, 1))
 
 
 def policy_net(env):
     return nn.Sequential(
-        nn.Linear(3456, 512),
-        nn.ReLU(),
-        Linear0(512, env.action_space.n)
+        nn.Linear(3456, 512), nn.ReLU(), Linear0(512, env.action_space.n)
     )
 
 
 def a2c(
-        clip_grad=0.1,
-        discount_factor=0.99,
-        entropy_loss_scaling=0.01,
-        alpha=0.99, # RMSprop alpha
-        eps=1e-4, # RMSprop epsilon
-        lr=1e-3,
-        feature_lr_scaling=0.25,
-        n_envs=16,
-        n_steps=5,
-        device=torch.device('cpu')
+    clip_grad=0.1,
+    discount_factor=0.99,
+    entropy_loss_scaling=0.01,
+    alpha=0.99,  # RMSprop alpha
+    eps=1e-4,  # RMSprop epsilon
+    lr=1e-3,
+    feature_lr_scaling=0.25,
+    n_envs=16,
+    n_steps=5,
+    device=torch.device("cpu"),
 ):
     def _a2c(envs, writer=DummyWriter()):
         env = envs[0]
@@ -56,17 +50,17 @@ def a2c(
         value_model = value_net().to(device)
         policy_model = policy_net(env).to(device)
 
-        feature_optimizer = RMSprop(feature_model.parameters(), alpha=alpha, lr=lr * feature_lr_scaling, eps=eps)
+        feature_optimizer = RMSprop(
+            feature_model.parameters(), alpha=alpha, lr=lr * feature_lr_scaling, eps=eps
+        )
         value_optimizer = RMSprop(value_model.parameters(), alpha=alpha, lr=lr, eps=eps)
-        policy_optimizer = RMSprop(policy_model.parameters(), alpha=alpha, lr=lr, eps=eps)
+        policy_optimizer = RMSprop(
+            policy_model.parameters(), alpha=alpha, lr=lr, eps=eps
+        )
 
-        features = FeatureNetwork(
-            feature_model, feature_optimizer, clip_grad=clip_grad)
+        features = FeatureNetwork(feature_model, feature_optimizer, clip_grad=clip_grad)
         v = ValueNetwork(
-            value_model,
-            value_optimizer,
-            clip_grad=clip_grad,
-            writer=writer
+            value_model, value_optimizer, clip_grad=clip_grad, writer=writer
         )
         policy = SoftmaxPolicy(
             policy_model,
@@ -74,7 +68,7 @@ def a2c(
             env.action_space.n,
             entropy_loss_scaling=entropy_loss_scaling,
             clip_grad=clip_grad,
-            writer=writer
+            writer=writer,
         )
         return ParallelAtariBody(
             A2C(
@@ -83,10 +77,11 @@ def a2c(
                 policy,
                 n_envs=n_envs,
                 n_steps=n_steps,
-                discount_factor=discount_factor
+                discount_factor=discount_factor,
             ),
-            envs
+            envs,
         )
+
     return _a2c, n_envs
 
 

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -33,16 +33,16 @@ def policy_net(env):
 
 
 def a2c(
-    clip_grad=0.1,
-    discount_factor=0.99,
-    entropy_loss_scaling=0.01,
-    alpha=0.99,  # RMSprop alpha
-    eps=1e-4,  # RMSprop epsilon
-    lr=1e-3,
-    feature_lr_scaling=0.25,
-    n_envs=16,
-    n_steps=5,
-    device=torch.device("cpu"),
+        clip_grad=0.1,
+        discount_factor=0.99,
+        entropy_loss_scaling=0.01,
+        alpha=0.99,  # RMSprop alpha
+        eps=1e-4,  # RMSprop epsilon
+        lr=1e-3,
+        feature_lr_scaling=0.25,
+        n_envs=16,
+        n_steps=5,
+        device=torch.device("cpu"),
 ):
     def _a2c(envs, writer=DummyWriter()):
         env = envs[0]

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -43,7 +43,7 @@ def a2c(
         discount_factor=0.99,
         entropy_loss_scaling=0.01,
         alpha=0.99, # RMSprop alpha
-        eps=1e-5, # RMSprop epsilon
+        eps=1e-4, # RMSprop epsilon
         lr=1e-3,
         n_envs=16,
         n_steps=5,
@@ -55,7 +55,7 @@ def a2c(
         value_model = value_net().to(device)
         policy_model = policy_net(env).to(device)
 
-        feature_optimizer = RMSprop(feature_model.parameters(), alpha=alpha, lr=lr, eps=eps)
+        feature_optimizer = RMSprop(feature_model.parameters(), alpha=alpha, lr=lr * 0.25, eps=eps)
         value_optimizer = RMSprop(value_model.parameters(), alpha=alpha, lr=lr, eps=eps)
         policy_optimizer = RMSprop(policy_model.parameters(), alpha=alpha, lr=lr, eps=eps)
 

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -45,6 +45,7 @@ def a2c(
         alpha=0.99, # RMSprop alpha
         eps=1e-4, # RMSprop epsilon
         lr=1e-3,
+        feature_lr_scaling=0.25,
         n_envs=16,
         n_steps=5,
         device=torch.device('cpu')
@@ -55,7 +56,7 @@ def a2c(
         value_model = value_net().to(device)
         policy_model = policy_net(env).to(device)
 
-        feature_optimizer = RMSprop(feature_model.parameters(), alpha=alpha, lr=lr * 0.25, eps=eps)
+        feature_optimizer = RMSprop(feature_model.parameters(), alpha=alpha, lr=lr * feature_lr_scaling, eps=eps)
         value_optimizer = RMSprop(value_model.parameters(), alpha=alpha, lr=lr, eps=eps)
         policy_optimizer = RMSprop(policy_model.parameters(), alpha=alpha, lr=lr, eps=eps)
 

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -47,7 +47,6 @@ def a2c(
         lr=2e-4,
         n_envs=16,
         n_steps=16,
-        update_frequency=16,
         device=torch.device('cpu')
 ):
     def _a2c(envs, writer=DummyWriter()):
@@ -82,8 +81,8 @@ def a2c(
                 features,
                 v,
                 policy,
+                n_envs=n_envs,
                 n_steps=n_steps,
-                update_frequency=update_frequency,
                 discount_factor=discount_factor
             ),
             envs

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -35,11 +35,12 @@ def policy_net(env):
 def a2c(
         clip_grad=0.1,
         discount_factor=0.99,
-        entropy_loss_scaling=0.01,
         alpha=0.99,  # RMSprop alpha
         eps=1e-4,  # RMSprop epsilon
         lr=1e-3,
-        feature_lr_scaling=0.25,
+        entropy_loss_scaling=0.01,
+        value_loss_scaling=0.25,
+        feature_lr_scaling=1,
         n_envs=16,
         n_steps=5,
         device=torch.device("cpu"),
@@ -60,7 +61,11 @@ def a2c(
 
         features = FeatureNetwork(feature_model, feature_optimizer, clip_grad=clip_grad)
         v = ValueNetwork(
-            value_model, value_optimizer, clip_grad=clip_grad, writer=writer
+            value_model,
+            value_optimizer,
+            loss_scaling=value_loss_scaling,
+            clip_grad=clip_grad,
+            writer=writer
         )
         policy = SoftmaxPolicy(
             policy_model,

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -27,10 +27,9 @@ def a2c(
         clip_grad=0.1,
         discount_factor=0.99,
         entropy_loss_scaling=0.001,
-        lr=3e-4,
+        lr=1e-3,
         n_envs=8,
         n_steps=8,
-        update_frequency=8,
         device=torch.device('cpu')
 ):
     def _a2c(envs, writer=DummyWriter()):
@@ -65,7 +64,6 @@ def a2c(
             policy,
             n_envs=n_envs,
             n_steps=n_steps,
-            update_frequency=update_frequency,
             discount_factor=discount_factor
         )
     return _a2c, n_envs

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -63,6 +63,7 @@ def a2c(
             features,
             v,
             policy,
+            n_envs=n_envs,
             n_steps=n_steps,
             update_frequency=update_frequency,
             discount_factor=discount_factor


### PR DESCRIPTION
The previous implementation of a2c was slightly off policy because it recomputed the probability of each state-action pair, and the policy may have changed in the meanwhile. It is now properly on policy, due to the use of the `NStepBatchBuffer`.