### PR TITLE
Feature/state

### DIFF
--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -24,7 +24,7 @@ class A2C(Agent):
         self._batch_size = n_envs * n_steps
         self._buffer = self._make_buffer()
 
-    def act(self, states, rewards, info=None):
+    def act(self, states, rewards):
         # store transition and train BEFORE choosing action
         # Do not need to know actions, so pass in empy array
         self._buffer.store(states, torch.zeros(self.n_envs), rewards)

--- a/all/agents/abstract.py
+++ b/all/agents/abstract.py
@@ -54,7 +54,7 @@ class Agent(ABC):
         action: The action to take at the current timestep
         """
 
-    def terminal(self, reward, info=None):
+    def terminal(self, state, reward, info=None):
         """
         Accept the final reward of the episode and perform final updates.
 

--- a/all/agents/abstract.py
+++ b/all/agents/abstract.py
@@ -11,7 +11,7 @@ class Agent(ABC):
     An Agent implementation should encapsulate some particular reinforcement learning algorihthm.
     """
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         """
         Choose an action in the initial state of a new episode.
 
@@ -31,7 +31,7 @@ class Agent(ABC):
         """
 
     @abstractmethod
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         """
         Select an action for the current timestep and update internal parameters.
 
@@ -54,7 +54,7 @@ class Agent(ABC):
         action: The action to take at the current timestep
         """
 
-    def terminal(self, state, reward, info=None):
+    def terminal(self, state, reward):
         """
         Accept the final reward of the episode and perform final updates.
 

--- a/all/agents/actor_critic.py
+++ b/all/agents/actor_critic.py
@@ -19,7 +19,7 @@ class ActorCritic(Agent):
         self.previous_state = state
         return self.policy(state)
 
-    def terminal(self, reward, info=None):
+    def terminal(self, state, reward):
         td_error = reward - self.v(self.previous_state)
         self.v.reinforce(td_error)
         self.policy.reinforce(td_error)

--- a/all/agents/actor_critic.py
+++ b/all/agents/actor_critic.py
@@ -7,11 +7,11 @@ class ActorCritic(Agent):
         self.gamma = gamma
         self.previous_state = None
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self.previous_state = state
         return self.policy(state)
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         if self.previous_state is not None:
             td_error = reward + self.gamma * self.v.eval(state) - self.v(self.previous_state)
             self.v.reinforce(td_error)

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -39,8 +39,8 @@ class DQN(Agent):
         self.action = self.policy(state)
         return self.action
 
-    def terminal(self, reward, info=None):
-        self.store_transition(None, reward)
+    def terminal(self, state, reward):
+        self.store_transition(state, reward)
         if self.should_train():
             self.train()
 

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -27,12 +27,12 @@ class DQN(Agent):
         self.state = None
         self.action = None
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self.state = state
         self.action = self.policy(self.state)
         return self.action
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         self.store_transition(state, reward)
         if self.should_train():
             self.train()

--- a/all/agents/sarsa.py
+++ b/all/agents/sarsa.py
@@ -12,12 +12,12 @@ class Sarsa(Agent):
         self.next_state = None
         self.next_action = None
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self.state = state
         self.action = self.policy(self.state)
         return self.action
 
-    def act(self, next_state, reward, info=None):
+    def act(self, next_state, reward):
         next_action = self.policy(next_state)
         td_error = (
             reward
@@ -29,6 +29,5 @@ class Sarsa(Agent):
         self.action = next_action
         return self.action
 
-    def terminal(self, reward, info=None):
-        td_error = reward - self.q(self.state, self.action)
-        self.q.reinforce(td_error)
+    def terminal(self, state, reward):
+        return self.act(state, reward)

--- a/all/agents/vpg.py
+++ b/all/agents/vpg.py
@@ -1,5 +1,6 @@
 import torch
 from .abstract import Agent
+from all.environments import State
 
 class VPG(Agent):
     def __init__(
@@ -16,30 +17,30 @@ class VPG(Agent):
         self.gamma = gamma
         self.n_episodes = n_episodes
         self._trajectories = []
-        self._states = None
+        self._features = None
         self._rewards = None
 
     def initial(self, state, info=None):
         features = self.features(state)
-        self._states = [features]
+        self._features = [features.features]
         self._rewards = []
         return self.policy(features)
 
     def act(self, state, reward, info=None):
         features = self.features(state)
-        self._states.append(features)
+        self._features.append(features.features)
         self._rewards.append(reward)
         return self.policy(features)
 
-    def terminal(self, reward, info=None):
+    def terminal(self, state, reward):
         self._rewards.append(reward)
-        states = torch.cat(self._states)
-        rewards = torch.tensor(self._rewards, device=states.device)
-        self._trajectories.append((states, rewards))
+        features = torch.cat(self._features)
+        rewards = torch.tensor(self._rewards, device=features.device)
+        self._trajectories.append((features, rewards))
         if len(self._trajectories) >= self.n_episodes:
             advantages = torch.cat([
-                self._compute_advantages(states, rewards)
-                for (states, rewards)
+                self._compute_advantages(features, rewards)
+                for (features, rewards)
                 in self._trajectories
             ])
             self.v.reinforce(advantages, retain_graph=True)
@@ -49,7 +50,7 @@ class VPG(Agent):
 
     def _compute_advantages(self, features, rewards):
         returns = self._compute_discounted_returns(rewards)
-        values = self.v(features)
+        values = self.v(State(features))
         return returns - values
 
     def _compute_discounted_returns(self, rewards):

--- a/all/agents/vpg.py
+++ b/all/agents/vpg.py
@@ -1,6 +1,6 @@
 import torch
-from .abstract import Agent
 from all.environments import State
+from .abstract import Agent
 
 class VPG(Agent):
     def __init__(
@@ -20,13 +20,13 @@ class VPG(Agent):
         self._features = None
         self._rewards = None
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         features = self.features(state)
         self._features = [features.features]
         self._rewards = []
         return self.policy(features)
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         features = self.features(state)
         self._features.append(features.features)
         self._rewards.append(reward)

--- a/all/approximation/v_network.py
+++ b/all/approximation/v_network.py
@@ -29,6 +29,7 @@ class ValueNetwork(ValueFunction):
 
     def __call__(self, states):
         result = self.model(states).squeeze(1)
+        print(states.features.shape, result.shape)
         self._cache.append(result)
         return result.detach()
 
@@ -43,6 +44,7 @@ class ValueNetwork(ValueFunction):
         td_errors = td_errors.view(-1)
         batch_size = len(td_errors)
         cache = self.decache(batch_size)
+        print(cache)
 
         if cache.requires_grad:
             targets = td_errors + cache.detach()
@@ -55,6 +57,7 @@ class ValueNetwork(ValueFunction):
             self.optimizer.zero_grad()
 
     def decache(self, batch_size):
+        print('before', len(self._cache))
         i = 0
         items = 0
         while items < batch_size and i < len(self._cache):
@@ -65,5 +68,5 @@ class ValueNetwork(ValueFunction):
 
         cache = torch.cat(self._cache[:i])
         self._cache = self._cache[i:]
-
+        print('after', len(self._cache))
         return cache

--- a/all/approximation/v_network.py
+++ b/all/approximation/v_network.py
@@ -29,7 +29,6 @@ class ValueNetwork(ValueFunction):
 
     def __call__(self, states):
         result = self.model(states).squeeze(1)
-        print(states.features.shape, result.shape)
         self._cache.append(result)
         return result.detach()
 
@@ -44,7 +43,6 @@ class ValueNetwork(ValueFunction):
         td_errors = td_errors.view(-1)
         batch_size = len(td_errors)
         cache = self.decache(batch_size)
-        print(cache)
 
         if cache.requires_grad:
             targets = td_errors + cache.detach()
@@ -57,7 +55,6 @@ class ValueNetwork(ValueFunction):
             self.optimizer.zero_grad()
 
     def decache(self, batch_size):
-        print('before', len(self._cache))
         i = 0
         items = 0
         while items < batch_size and i < len(self._cache):
@@ -68,5 +65,4 @@ class ValueNetwork(ValueFunction):
 
         cache = torch.cat(self._cache[:i])
         self._cache = self._cache[i:]
-        print('after', len(self._cache))
         return cache

--- a/all/approximation/v_network_test.py
+++ b/all/approximation/v_network_test.py
@@ -35,8 +35,6 @@ class TestVNetwork(unittest.TestCase):
             torch.randn(5, STATE_DIM),
             done=torch.tensor([1, 1, 0, 1, 0, 0])
         )
-        print('hello')
-        print(states.features.shape)
         self.v(states[0:2])
         self.v(states[2:4])
         self.v(states[4:6])

--- a/all/approximation/v_network_test.py
+++ b/all/approximation/v_network_test.py
@@ -3,10 +3,11 @@ import torch
 from torch import nn
 import torch_testing as tt
 from all.approximation.v_network import ValueNetwork
+from all.environments import State
 
 STATE_DIM = 2
 
-class TestQNetwork(unittest.TestCase):
+class TestVNetwork(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(2)
         self.model = nn.Sequential(
@@ -17,30 +18,25 @@ class TestQNetwork(unittest.TestCase):
         self.v = ValueNetwork(self.model, optimizer)
 
     def test_reinforce_list(self):
-        states = [
-            torch.randn(1, STATE_DIM),
-            torch.randn(1, STATE_DIM),
-            None,
-            torch.randn(1, STATE_DIM),
-            None
-        ]
+        states = State(
+            torch.randn(5, STATE_DIM),
+            done=torch.tensor([1, 1, 0, 1, 0])
+        )
         result = self.v(states)
         tt.assert_almost_equal(result, torch.tensor(
-            [0.7053187, 0.3975691, 0., 0.0480383, 0.]))
+            [0.7053187, 0.3975691, 0., 0.2701665, 0.]))
         self.v.reinforce(torch.tensor([1, -1, 1, 1, 1]).float())
         result = self.v(states)
         tt.assert_almost_equal(result, torch.tensor(
-            [0.8042525, 0.4606972, 0., 0.0714759, 0.]))
+            [0.9732854, 0.5453826, 0., 0.4344811, 0.]))
 
     def test_multi_reinforce(self):
-        states = [
-            torch.randn(1, STATE_DIM),
-            torch.randn(1, STATE_DIM),
-            None,
-            torch.randn(1, STATE_DIM),
-            None,
-            None
-        ]
+        states = State(
+            torch.randn(5, STATE_DIM),
+            done=torch.tensor([1, 1, 0, 1, 0, 0])
+        )
+        print('hello')
+        print(states.features.shape)
         self.v(states[0:2])
         self.v(states[2:4])
         self.v(states[4:6])

--- a/all/bodies/abstract.py
+++ b/all/bodies/abstract.py
@@ -19,11 +19,11 @@ class Body(Agent):
     def agent(self, agent):
         self._agent = agent
 
-    def initial(self, state, info=None):
-        return self.agent.initial(state, info)
+    def initial(self, state):
+        return self.agent.initial(state)
 
-    def act(self, state, reward, info=None):
-        return self.agent.act(state, reward, info)
+    def act(self, state, reward):
+        return self.agent.act(state, reward)
 
-    def terminal(self, reward, info=None):
-        return self.agent.terminal(reward, info)
+    def terminal(self, state, reward):
+        return self.agent.terminal(state, reward)

--- a/all/bodies/atari.py
+++ b/all/bodies/atari.py
@@ -1,5 +1,6 @@
 import torch
 import numpy as np
+from all.environments import State
 from .abstract import Body
 from .parallel import ParallelBody, ParallelRepeatActions
 
@@ -13,42 +14,61 @@ class NoopBody(Body):
         self.noops = 0
         self.actions_taken = 0
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self.noops = np.random.randint(self.noop_max) + 1
         self.actions_taken = 0
         return NOOP_ACTION
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         self.actions_taken += 1
         if self.actions_taken < self.noops:
             return NOOP_ACTION
         if self.actions_taken == self.noops:
-            return self.agent.initial(state, info)
+            return self.agent.initial(state)
         return self.agent.act(state, reward)
 
-    def terminal(self, reward, info=None):
+    def terminal(self, state, reward):
         if self.actions_taken >= self.noops:
-            self.agent.terminal(reward, info)
+            self.agent.terminal(state, reward)
         # otherwise, the poor agent never stood a chance
 
 class Deflicker(Body):
     _previous_frame = None
 
-    def initial(self, frame, info=None):
-        self._previous_frame = frame
-        return self.agent.initial(frame, info)
+    def initial(self, state):
+        self._previous_frame = state.raw
+        return self.agent.initial(state)
 
-    def act(self, frame, reward, info=None):
+    def act(self, state, reward):
+        frame = state.raw
         frame, self._previous_frame = torch.max(
             frame, self._previous_frame), frame
-        return self.agent.act(frame, reward, info)
+        deflickered = State(frame, state.done, state.info)
+        return self.agent.act(deflickered, reward)
 
 class AtariVisionPreprocessor(Body):
-    def initial(self, frame, info=None):
-        return self.agent.initial(self._preprocess(frame), info)
+    def initial(self, state):
+        return self.agent.initial(State(
+            self._preprocess(state.raw),
+            state.done,
+            state.info
+        ))
 
-    def act(self, frame, reward, info=None):
-        return self.agent.act(self._preprocess(frame), reward, info)
+    def act(self, state, reward):
+        state = State(
+            self._preprocess(state.raw),
+            state.done,
+            state.info
+        )
+        return self.agent.act(state, reward)
+
+    def terminal(self, state, reward):
+        state = State(
+            self._preprocess(state.raw),
+            state.done,
+            state.info
+        )
+        return self.agent.terminal(state, reward)
 
     def _preprocess(self, frame):
         return to_grayscale(downsample(frame)).unsqueeze(1)
@@ -62,16 +82,38 @@ def downsample(frame):
 class FrameStack(Body):
     def __init__(self, agent, size=4):
         super().__init__(agent)
-        self._state = []
+        self._frames = []
         self._size = size
 
-    def initial(self, state, info=None):
-        self._state = [state] * self._size
-        return self.agent.initial(stack(self._state), info)
+    def initial(self, state):
+        self._frames = [state.raw] * self._size
+        return self.agent.initial(State(
+            stack(self._frames),
+            state.done,
+            state.info
+        ))
 
-    def act(self, state, reward, info=None):
-        self._state = self._state[1:] + [state]
-        return self.agent.act(stack(self._state), reward, info)
+    def act(self, state, reward):
+        self._frames = self._frames[1:] + [state.raw]
+        return self.agent.act(
+            State(
+                stack(self._frames),
+                state.done,
+                state.info
+            ),
+            reward
+        )
+
+    def terminal(self, state, reward):
+        self._frames = self._frames[1:] + [state.raw]
+        return self.agent.act(
+            State(
+                stack(self._frames),
+                state.done,
+                state.info
+            ),
+            reward
+        )
 
 def stack(frames):
     return torch.cat(frames, dim=1)
@@ -82,16 +124,17 @@ class EpisodicLives(Body):
         self._env = env
         self._lives = 0
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self._lives = self._get_lives()
-        return self.agent.initial(state, info)
+        return self.agent.initial(state)
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         if self._lost_life():
-            self.terminal(reward, info)
+            state = State(state.raw, state.mask * 0, state.info)
+            self.terminal(state, reward)
             self._lives = self._get_lives()
-            return self.initial(state, info)
-        return self.agent.act(state, reward, info)
+            return self.initial(state)
+        return self.agent.act(state, reward)
 
     def _lost_life(self):
         lives = self._get_lives()
@@ -106,25 +149,25 @@ class FireOnReset(Body):
         super().__init__(agent)
         self._frames = 0
 
-    def initial(self, state, info=None):
+    def initial(self, state):
         self._frames = 1
         return torch.tensor([1])
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         if self._frames == 1:
             self._frames += 1
             return torch.tensor([2])
         if self._frames == 2:
             self._frames += 1
-            return self.agent.initial(state, info)
-        return self.agent.act(state, reward, info)
+            return self.agent.initial(state)
+        return self.agent.act(state, reward)
 
 class RewardClipping(Body):
-    def act(self, state, reward, info=None):
-        return self.agent.act(state, np.sign(reward), info)
+    def act(self, state, reward):
+        return self.agent.act(state, np.sign(reward))
 
-    def terminal(self, reward, info=None):
-        return self.agent.terminal(np.sign(reward), info)
+    def terminal(self, state, reward):
+        return self.agent.terminal(state, np.sign(reward))
 
 class RepeatActions(Body):
     def __init__(self, agent, repeats=4):
@@ -134,24 +177,24 @@ class RepeatActions(Body):
         self._action = None
         self._reward = 0
 
-    def initial(self, state, info=None):
-        self._action = self.agent.initial(state, info)
+    def initial(self, state):
+        self._action = self.agent.initial(state)
         self._reward = 0
         self._count = 0
         return self._action
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         self._count += 1
         self._reward += reward
         if self._count == self._repeats:
-            self._action = self.agent.act(state, self._reward, info)
+            self._action = self.agent.act(state, self._reward)
             self._reward = 0
             self._count = 0
         return self._action
 
-    def terminal(self, reward, info=None):
+    def terminal(self, state, reward):
         self._reward += reward
-        return self.agent.terminal(self._reward, info)
+        return self.agent.terminal(state, self._reward)
 
 class DeepmindAtariBody(Body):
     '''

--- a/all/bodies/parallel.py
+++ b/all/bodies/parallel.py
@@ -10,14 +10,14 @@ class ParallelRepeatActions(Body):
         self._actions = None
         self._rewards = None
 
-    def act(self, states, rewards, info=None):
+    def act(self, states, rewards):
         if self._rewards is None:
             self._rewards = rewards.clone()
         else:
             self._rewards += rewards
         self._count += 1
         if self._count >= self._repeats:
-            self._actions = list(self.agent.act(states, self._rewards, info))
+            self._actions = list(self.agent.act(states, self._rewards))
             self._rewards = self._rewards * 0
             self._count = 0
         else:

--- a/all/bodies/parallel_test.py
+++ b/all/bodies/parallel_test.py
@@ -16,7 +16,7 @@ class MockAgent(Agent):
         self._states = []
         self._rewards = []
 
-    def act(self, state, reward, info=None):
+    def act(self, state, reward):
         self._actions = (self._actions + 1) % self._max_action
         self._states.append(state)
         self._rewards.append(reward.view(1, -1))

--- a/all/environments/__init__.py
+++ b/all/environments/__init__.py
@@ -1,5 +1,6 @@
 from .abstract import Environment
 from .gym import GymEnvironment
 from .atari import AtariEnvironment
+from .state import State
 
-__all__ = ["Environment", "GymEnvironment", "AtariEnvironment"]
+__all__ = ["Environment", "State", "GymEnvironment", "AtariEnvironment"]

--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -15,6 +15,19 @@ class GymEnvironment(Environment):
         self._info = None
         self._device = device
 
+        # predefining these saves performance on tensor creation
+        # it actually makes a noticable difference :p
+        self._done_mask = torch.tensor(
+            [0],
+            dtype=torch.uint8,
+            device=self._device
+        )
+        self._not_done_mask = torch.tensor(
+            [1],
+            dtype=torch.uint8,
+            device=self._device
+        )
+
     @property
     def name(self):
         return self._name
@@ -91,10 +104,6 @@ class GymEnvironment(Environment):
                     dtype=self.state_space.dtype
                 )
             ).unsqueeze(0).to(self._device),
-            torch.tensor(
-                [int(not done)],
-                dtype=torch.uint8,
-                device=self._device
-            ),
+            self._done_mask if done else self._not_done_mask,
             info
         )

--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -21,8 +21,7 @@ class GymEnvironment(Environment):
 
     def reset(self):
         state = self._env.reset()
-        self._state = self._make_state(state, False, None)
-        self._done = False
+        self._state = self._make_state(state, 0, None)
         self._reward = 0
         return self._state
 
@@ -31,6 +30,7 @@ class GymEnvironment(Environment):
         self._state = self._make_state(state, done, info)
         self._action = action
         self._reward = reward
+        self._done = done
         return self._state, self._reward
 
     def render(self):
@@ -67,7 +67,7 @@ class GymEnvironment(Environment):
 
     @property
     def done(self):
-        return self._state.done
+        return self._done
 
     @property
     def info(self):
@@ -90,6 +90,10 @@ class GymEnvironment(Environment):
                     dtype=self.state_space.dtype
                 )
             ).unsqueeze(0).to(self._device),
-            done,
+            torch.tensor(
+                [int(not done)],
+                dtype=torch.uint8,
+                device=self._device
+            ),
             info
         )

--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -23,6 +23,7 @@ class GymEnvironment(Environment):
         state = self._env.reset()
         self._state = self._make_state(state, 0, None)
         self._reward = 0
+        self._done = False
         return self._state
 
     def step(self, action):

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -11,6 +11,8 @@ class State:
                 device=raw.device
             )
         self._info = info
+        if info is None:
+            self._info = [None] * len(raw)
 
     @classmethod
     def from_list(cls, states):

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -1,7 +1,15 @@
+import torch
+
 class State:
-    def __init__(self, raw, done, info=None):
+    def __init__(self, raw, done=None, info=None):
         self._raw = raw
         self._done = done
+        if done is None:
+            self._done = torch.ones(
+                len(raw),
+                dtype=torch.uint8,
+                device=raw.device
+            )
         self._info = info
 
     @property

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -12,6 +12,13 @@ class State:
             )
         self._info = info
 
+    @classmethod
+    def from_list(cls, states):
+        raw = torch.cat([state.raw for state in states])
+        done = torch.cat([state.done for state in states])
+        info = [state.info for state in states]
+        return cls(raw, done, info)
+
     @property
     def features(self):
         '''
@@ -25,5 +32,20 @@ class State:
         return self._done
 
     @property
+    def mask(self):
+        return self._done
+
+    @property
     def info(self):
         return self._info
+
+    @property
+    def raw(self):
+        return self._raw
+
+    def __getitem__(self, idx):
+        return State(
+            self._raw[idx].unsqueeze(0),
+            self._done[idx].unsqueeze(0),
+            self._info[idx]
+        )

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -1,0 +1,21 @@
+class State:
+    def __init__(self, raw, done, info):
+        self._raw = raw
+        self._done = done
+        self._info = info
+
+    @property
+    def features(self):
+        '''
+        Default features are the raw state.
+        Override this method for other types of features.
+        '''
+        return self._raw
+
+    @property
+    def done(self):
+        return self._done
+
+    @property
+    def info(self):
+        return self._info

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -46,6 +46,12 @@ class State:
         return self._raw
 
     def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return State(
+                self._raw[idx],
+                self._done[idx],
+                self._info[idx]
+            )
         return State(
             self._raw[idx].unsqueeze(0),
             self._done[idx].unsqueeze(0),

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -1,5 +1,5 @@
 class State:
-    def __init__(self, raw, done, info):
+    def __init__(self, raw, done, info=None):
         self._raw = raw
         self._done = done
         self._info = info

--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -78,7 +78,7 @@ class Experiment:
             self._writer.frames = self._frames
 
         # terminal state
-        agent.terminal(env.reward)
+        agent.terminal(env.state, env.reward)
 
         # log info
         end = timer()

--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -1,7 +1,7 @@
 from timeit import default_timer as timer
 import numpy as np
 import torch
-from all.environments import GymEnvironment
+from all.environments import GymEnvironment, State
 from .writer import ExperimentWriter
 
 
@@ -97,7 +97,7 @@ class Experiment:
         returns = torch.zeros((n_envs)).float().to(self.env.device)
         start = timer()
         while not self._done():
-            states = [env.state for env in envs]
+            states = State.from_list([env.state for env in envs])
             rewards = torch.tensor([env.reward for env in envs]).float().to(self.env.device)
             actions = agent.act(states, rewards)
             for i, env in enumerate(envs):

--- a/all/experiments/experiment_test.py
+++ b/all/experiments/experiment_test.py
@@ -57,7 +57,7 @@ class TestExperiment(unittest.TestCase):
         self.experiment.run(sarsa(), console=False)
         np.testing.assert_equal(
             self.experiment._writer.data["evaluation/returns-by-episode"]["values"],
-            np.array([9., 11., 10.])
+            np.array([9., 12., 10.])
         )
         np.testing.assert_equal(
             self.experiment._writer.data["evaluation/returns-by-episode"]["steps"],

--- a/all/experiments/writer.py
+++ b/all/experiments/writer.py
@@ -36,7 +36,7 @@ class ExperimentWriter(SummaryWriter, Writer):
         self.env_name = env_name
         current_time = str(datetime.now())
         log_dir = os.path.join(
-            'runs', ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
+            'runs2', ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
         )
         self._frames = 0
         self._episodes = 1

--- a/all/experiments/writer.py
+++ b/all/experiments/writer.py
@@ -36,7 +36,7 @@ class ExperimentWriter(SummaryWriter, Writer):
         self.env_name = env_name
         current_time = str(datetime.now())
         log_dir = os.path.join(
-            'runs2', ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
+            'runs', ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
         )
         self._frames = 0
         self._episodes = 1

--- a/all/layers/__init__.py
+++ b/all/layers/__init__.py
@@ -29,7 +29,7 @@ class ListToList(nn.Module):
         self.device = next(model.parameters()).device
 
     def forward(self, state):
-        return State(self.model(state.features), state.done, state.info)
+        return State(self.model(state.features.float()), state.done, state.info)
 
 class Aggregation(nn.Module):
     '''len()

--- a/all/layers/__init__.py
+++ b/all/layers/__init__.py
@@ -16,7 +16,7 @@ class ListNetwork(nn.Module):
         self.device = next(model.parameters()).device
 
     def forward(self, state):
-        return self.model(state.features) * state.done.float().unsqueeze(-1)
+        return self.model(state.features.float()) * state.done.float().unsqueeze(-1)
 
 class ListToList(nn.Module):
     '''

--- a/all/layers/__init__.py
+++ b/all/layers/__init__.py
@@ -16,7 +16,7 @@ class ListNetwork(nn.Module):
         self.device = next(model.parameters()).device
 
     def forward(self, state):
-        return (self.model(state.features.float()).transpose(0, 1) * state.done.float()).transpose(0, 1)
+        return self.model(state.features) * state.done.float().unsqueeze(-1)
 
 class ListToList(nn.Module):
     '''

--- a/all/layers/test.py
+++ b/all/layers/test.py
@@ -52,25 +52,26 @@ class TestLayers(unittest.TestCase):
     def test_list_to_list(self):
         model = nn.Linear(2, 2)
         net = ListToList(model)
-        x = [torch.randn(1, 2), torch.randn(1, 2), None, torch.randn(1, 2)]
+        x = State(torch.randn(5, 2), torch.tensor([1, 1, 1, 0, 1]))
         out = net(x)
-        self.assert_array_equal(out, [torch.tensor([[0.0479387, -0.2268031]]),
-                                      torch.tensor([[0.2346841, 0.0743403]]),
-                                      None,
-                                      torch.tensor([[0.0185191, 0.0815052]])])
-
-        x = torch.randn(3, 2)
+        tt.assert_almost_equal(out.features, torch.tensor([
+            [0.0479, -0.2268],
+            [0.2347, 0.0743],
+            [0.0185, 0.0815],
+            [0.2204, 0.0868],
+            [0.4235, 0.1040]
+        ]), decimal=3)
+        x = State(torch.randn(3, 2))
         out = net(x)
-        tt.assert_almost_equal(out, torch.tensor([[0.2204496, 0.086818],
-                                                  [0.4234636, 0.1039939],
-                                                  [0.6514298, 0.3354351]]))
+        tt.assert_almost_equal(out.features, torch.tensor([
+            [0.651, 0.335],
+            [-0.254, -0.204],
+            [0.123, 0.218]
+        ]), decimal=3)
 
-        x = torch.randn(2)
+        x = State(torch.randn(2))
         out = net(x)
-        tt.assert_almost_equal(out, torch.tensor([-0.2543002, -0.2041451]))
-
-        out = net(None)
-        self.assertIsNone(out)
+        tt.assert_almost_equal(out.features, torch.tensor([0.3218211, 0.3707529]), decimal=3)
 
     def assert_array_equal(self, actual, expected):
         for first, second in zip(actual, expected):

--- a/all/layers/test.py
+++ b/all/layers/test.py
@@ -34,20 +34,20 @@ class TestLayers(unittest.TestCase):
     def test_list(self):
         model = nn.Linear(2, 2)
         net = ListNetwork(model, (2,))
-        features = torch.cat([torch.randn(1, 2), torch.randn(1, 2), torch.zeros(1, 2), torch.randn(1, 2)])
+        features = torch.randn((4, 2))
         done = torch.tensor([1, 1, 0, 1], dtype=torch.uint8)
         out = net(State(features, done))
         tt.assert_almost_equal(out, torch.tensor([[0.0479387, -0.2268031],
                                                   [0.2346841, 0.0743403],
                                                   [0., 0.],
-                                                  [0.0185191, 0.0815052]]))
+                                                  [0.2204496, 0.086818]]))
 
         features = torch.randn(3, 2)
         done = torch.tensor([1, 1, 1], dtype=torch.uint8)
         out = net(State(features, done))
-        tt.assert_almost_equal(out, torch.tensor([[0.2204496, 0.086818],
-                                                  [0.4234636, 0.1039939],
-                                                  [0.6514298, 0.3354351]]))
+        tt.assert_almost_equal(out, torch.tensor([[0.4234636, 0.1039939],
+                                                  [0.6514298, 0.3354351],
+                                                  [-0.2543002, -0.2041451]]))
 
     def test_list_to_list(self):
         model = nn.Linear(2, 2)

--- a/all/layers/test.py
+++ b/all/layers/test.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 import torch_testing as tt
 from all.layers import Dueling, Linear0, ListNetwork, ListToList
+from all.environments import State
 
 
 class TestLayers(unittest.TestCase):
@@ -33,25 +34,20 @@ class TestLayers(unittest.TestCase):
     def test_list(self):
         model = nn.Linear(2, 2)
         net = ListNetwork(model, (2,))
-        x = [torch.randn(1, 2), torch.randn(1, 2), None, torch.randn(1, 2)]
-        out = net(x)
+        features = torch.cat([torch.randn(1, 2), torch.randn(1, 2), torch.zeros(1, 2), torch.randn(1, 2)])
+        done = torch.tensor([1, 1, 0, 1], dtype=torch.uint8)
+        out = net(State(features, done))
         tt.assert_almost_equal(out, torch.tensor([[0.0479387, -0.2268031],
                                                   [0.2346841, 0.0743403],
                                                   [0., 0.],
                                                   [0.0185191, 0.0815052]]))
 
-        x = torch.randn(3, 2)
-        out = net(x)
+        features = torch.randn(3, 2)
+        done = torch.tensor([1, 1, 1], dtype=torch.uint8)
+        out = net(State(features, done))
         tt.assert_almost_equal(out, torch.tensor([[0.2204496, 0.086818],
                                                   [0.4234636, 0.1039939],
                                                   [0.6514298, 0.3354351]]))
-
-        x = torch.randn(2)
-        out = net(x)
-        tt.assert_almost_equal(out, torch.tensor([-0.2543002, -0.2041451]))
-
-        out = net(None)
-        tt.assert_equal(out, torch.tensor([0, 0]))
 
     def test_list_to_list(self):
         model = nn.Linear(2, 2)

--- a/all/memory/n_step.py
+++ b/all/memory/n_step.py
@@ -25,7 +25,7 @@ class NStepBuffer:
             discount = self.gamma ** (self.n - 1)
             for i, v in enumerate(self._temp[0]):
                 state, action, reward, last_state, length = v
-                if last_state is None:
+                if last_state.mask == 0:
                     self._store(state, action, reward, last_state, length)
                 else:
                     reward += discount * rewards[i]
@@ -37,7 +37,7 @@ class NStepBuffer:
             discount = self.gamma ** (len(self._temp) - 1 - t)
             for i, v in enumerate(_temp):
                 state, action, reward, last_state, length = v
-                if last_state is not None:
+                if last_state.mask == 1:
                     reward += discount * rewards[i]
                     last_state = states[i]
                     length += 1
@@ -73,6 +73,8 @@ class NStepBuffer:
         self._rewards = self._rewards[batch_size:]
         self._lengths = self._lengths[batch_size:]
 
+        states = State.from_list(states)
+        next_states = State.from_list(next_states)
         return states, actions, next_states, rewards, lengths
 
     def _store(self, state, action, reward, next_state, length):

--- a/all/memory/n_step_test.py
+++ b/all/memory/n_step_test.py
@@ -1,6 +1,7 @@
 import unittest
 import torch
 import torch_testing as tt
+from all.environments import State
 from all.memory import NStepBuffer, NStepBatchBuffer
 
 
@@ -8,15 +9,16 @@ class NStepBufferTest(unittest.TestCase):
     def test_rollout(self):
         buffer = NStepBuffer(2, discount_factor=0.5)
         actions = torch.ones((3))
-        buffer.store(['state1', 'state2', 'state3'], actions, torch.zeros(3))
-        buffer.store(['state4', 'state5', 'state6'], actions, torch.ones(3))
-        buffer.store(['state7', 'state8', 'state9'], actions, 2 * torch.ones(3))
-        buffer.store(['state10', 'state11', 'state12'], actions, 4 * torch.ones(3))
+        states = State(torch.arange(0, 12))
+        buffer.store(states[0:3], actions, torch.zeros(3))
+        buffer.store(states[3:6], actions, torch.ones(3))
+        buffer.store(states[6:9], actions, 2 * torch.ones(3))
+        buffer.store(states[9:12], actions, 4 * torch.ones(3))
         self.assertEqual(len(buffer), 6)
 
         states, actions, next_states, returns, lengths = buffer.sample(6)
-        expected_states = ['state' + str(i) for i in range(1, 7)]
-        expected_next_states = ['state' + str(i) for i in range(7, 13)]
+        expected_states = State(torch.arange(0, 6))
+        expected_next_states = State(torch.arange(6, 12))
         expected_returns = torch.tensor([
             2, 2, 2,
             4, 4, 4,
@@ -25,34 +27,30 @@ class NStepBufferTest(unittest.TestCase):
             2, 2, 2,
             2, 2, 2,
         ])
-        self.assert_array_equal(states, expected_states)
-        self.assert_array_equal(next_states, expected_next_states)
+        self.assert_states_equal(states, expected_states)
+        self.assert_states_equal(next_states, expected_next_states)
         tt.assert_allclose(returns, expected_returns)
         tt.assert_equal(lengths, expected_lengths)
 
     def test_rollout_with_nones(self):
         buffer = NStepBuffer(3, discount_factor=0.5)
-        states = [
-            ['state1', 'state2', 'state3'],
-            ['state4', 'state5', None],
-            ['state7', None, 'state9'],
-            [None, 'state11', 'state12'],
-            ['state13', 'state14', 'state15']
-        ]
+        done = torch.ones(16)
+        done[5] = 0
+        done[7] = 0
+        done[9] = 0
+        states = State(torch.arange(0, 16))
         actions = torch.ones((3))
-        buffer.store(states[0], actions, torch.zeros(3))
-        buffer.store(states[1], actions, torch.ones(3))
-        buffer.store(states[2], actions, 2 * torch.ones(3))
-        buffer.store(states[3], actions, 4 * torch.ones(3))
-        buffer.store(states[4], actions, 8 * torch.ones(3))
+        buffer.store(states[0:3], actions, torch.zeros(3))
+        buffer.store(states[3:6], actions, torch.ones(3))
+        buffer.store(states[6:9], actions, 2 * torch.ones(3))
+        buffer.store(states[9:12], actions, 4 * torch.ones(3))
+        buffer.store(states[12:15], actions, 8 * torch.ones(3))
         states, actions, next_states, returns, lengths = buffer.sample(6)
 
-        expected_states = ['state' + str(i + 1) for i in range(6)]
-        expected_states[5] = None
-        expect_next_states = [
-            None, None, None,
-            None, None, None,
-        ]
+        expected_states = State(torch.arange(0, 6))
+        expect_next_states = State(torch.tensor([
+            9, 7, 5, 9, 7, 5
+        ]))
         expected_returns = torch.tensor([
             3, 2, 1,
             4, 2, 0,
@@ -62,8 +60,8 @@ class NStepBufferTest(unittest.TestCase):
             2, 1, 0,
         ])
 
-        self.assert_array_equal(states, expected_states)
-        self.assert_array_equal(next_states, expect_next_states)
+        self.assert_states_equal(states, expected_states)
+        self.assert_states_equal(next_states, expect_next_states)
         tt.assert_allclose(returns, expected_returns)
         tt.assert_equal(lengths, expected_lengths)
 
@@ -102,20 +100,22 @@ class NStepBufferTest(unittest.TestCase):
             self.assertEqual(actual[i], exp, msg=(
                 ("\nactual: %s\nexpected: %s") % (actual, expected)))
 
+    def assert_states_equal(self, actual, expected):
+        tt.assert_almost_equal(actual.raw, expected.raw)
+        tt.assert_equal(actual.mask, expected.mask)
+
 class NStepBatchBufferTest(unittest.TestCase):
     def test_rollout(self):
         buffer = NStepBatchBuffer(2, 3, discount_factor=0.5)
         actions = torch.ones((3))
-        buffer.store(['state1', 'state2', 'state3'], actions, torch.zeros(3))
-        buffer.store(['state4', 'state5', 'state6'], actions, torch.ones(3))
-        buffer.store(['state7', 'state8', 'state9'], actions, 4 * torch.ones(3))
+        states = State(torch.arange(0, 12))
+        buffer.store(states[0:3], actions, torch.zeros(3))
+        buffer.store(states[3:6], actions, torch.ones(3))
+        buffer.store(states[6:9], actions, 4 * torch.ones(3))
         states, _, next_states, returns, lengths = buffer.sample(-1)
 
-        expected_states = ['state' + str(i + 1) for i in range(6)]
-        expect_next_states = [
-            'state7', 'state8', 'state9',
-            'state7', 'state8', 'state9',
-        ]
+        expected_states = State(torch.arange(0, 6))
+        expect_next_states = State(torch.cat((torch.arange(6, 9), torch.arange(6, 9))))
         expected_returns = torch.tensor([
             3, 3, 3,
             4, 4, 4
@@ -125,34 +125,33 @@ class NStepBatchBufferTest(unittest.TestCase):
             1, 1, 1
         ]).long()
 
-        self.assert_array_equal(states, expected_states)
-        self.assert_array_equal(next_states, expect_next_states)
+        self.assert_states_equal(states, expected_states)
+        self.assert_states_equal(next_states, expect_next_states)
         tt.assert_allclose(returns, expected_returns)
         tt.assert_equal(lengths, expected_lengths)
 
     def test_rollout_with_nones(self):
         buffer = NStepBatchBuffer(3, 3, discount_factor=0.5)
-        states = [
-            ['state1', 'state2', 'state3'],
-            ['state4', 'state5', None],
-            ['state7', None, 'state9'],
-            [None, 'state11', 'state12']
-        ]
+        done = torch.ones(12)
+        done[5] = 0
+        done[7] = 0
+        done[9] = 0
+        states = State(torch.arange(0, 12), done)
         actions = torch.ones((3))
-        buffer.store(states[0], actions, torch.zeros(3))
-        buffer.store(states[1], actions, torch.ones(3))
-        buffer.store(states[2], actions, 2 * torch.ones(3))
-        buffer.store(states[3], actions, 4 * torch.ones(3))
+        buffer.store(states[0:3], actions, torch.zeros(3))
+        buffer.store(states[3:6], actions, torch.ones(3))
+        buffer.store(states[6:9], actions, 2 * torch.ones(3))
+        buffer.store(states[9:12], actions, 4 * torch.ones(3))
         states, actions, next_states, returns, lengths = buffer.sample(-1)
 
-        expected_states = ['state' + str(i + 1) for i in range(9)]
-        expected_states[5] = None
-        expected_states[7] = None
-        expect_next_states = [
-            None, None, None,
-            None, None, None,
-            None, None, 'state12',
-        ]
+        expected_states = State(torch.arange(0, 9), done[0:9])
+        expected_next_done = torch.zeros(9)
+        expected_next_done[8] = 1
+        expect_next_states = State(torch.tensor([
+            9, 7, 5,
+            9, 7, 5,
+            9, 7, 11
+        ]), expected_next_done)
         expected_returns = torch.tensor([
             3, 2, 1,
             4, 2, 0,
@@ -164,24 +163,22 @@ class NStepBatchBufferTest(unittest.TestCase):
             1, 0, 1
         ]).float()
 
-        self.assert_array_equal(states, expected_states)
-        self.assert_array_equal(next_states, expect_next_states)
+        self.assert_states_equal(states, expected_states)
+        self.assert_states_equal(next_states, expect_next_states)
         tt.assert_allclose(returns, expected_returns)
         tt.assert_equal(lengths, expected_lengths)
 
     def test_multi_rollout(self):
         buffer = NStepBatchBuffer(2, 2, discount_factor=0.5)
-        raw_states = ['state' + str(i) for i in range(12)]
+        raw_states = State(torch.arange(0, 12))
         actions = torch.ones((2))
         buffer.store(raw_states[0:2], actions, torch.ones(2))
         buffer.store(raw_states[2:4], actions, torch.ones(2))
         buffer.store(raw_states[4:6], actions, torch.ones(2))
 
         states, actions, next_states, returns, lengths = buffer.sample(-1)
-        self.assert_array_equal(states, ['state' + str(i) for i in range(4)])
-        self.assert_array_equal(next_states, [
-            'state4', 'state5', 'state4', 'state5'
-        ])
+        self.assert_states_equal(states, State(torch.arange(0, 4)))
+        self.assert_states_equal(next_states, State(torch.tensor([4, 5, 4, 5])))
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
         tt.assert_equal(lengths, torch.tensor([2, 2, 1, 1]))
 
@@ -189,11 +186,8 @@ class NStepBatchBufferTest(unittest.TestCase):
         buffer.store(raw_states[8:10], actions, torch.ones(2))
 
         states, actions, next_states, returns, lengths = buffer.sample(-1)
-        self.assert_array_equal(
-            states, ['state' + str(i) for i in range(4, 8)])
-        self.assert_array_equal(next_states, [
-            'state8', 'state9', 'state8', 'state9'
-        ])
+        self.assert_states_equal(states, State(torch.arange(4, 8)))
+        self.assert_states_equal(next_states, State(torch.tensor([8, 9, 8, 9])))
         tt.assert_allclose(returns, torch.tensor([1.5, 1.5, 1, 1]))
         tt.assert_equal(lengths, torch.tensor([2, 2, 1, 1]))
 
@@ -201,6 +195,10 @@ class NStepBatchBufferTest(unittest.TestCase):
         for i, exp in enumerate(expected):
             self.assertEqual(actual[i], exp, msg=(
                 ("\nactual: %s\nexpected: %s") % (actual, expected)))
+
+    def assert_states_equal(self, actual, expected):
+        tt.assert_almost_equal(actual.raw, expected.raw)
+        tt.assert_equal(actual.mask, expected.mask)
 
 
 if __name__ == '__main__':

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import random
 import numpy as np
 import torch
+from all.environments import State
 from .segment_tree import SumSegmentTree, MinSegmentTree
 
 class ReplayBuffer(ABC):
@@ -46,11 +47,17 @@ class ExperienceReplayBuffer(ReplayBuffer):
         self.pos = (self.pos + 1) % self.capacity
 
     def _reshape(self, minibatch, weights):
-        states = [sample[0] for sample in minibatch]
+        states = self._make_state([sample[0] for sample in minibatch])
         actions = [sample[1] for sample in minibatch]
-        next_states = [sample[2] for sample in minibatch]
+        next_states = self._make_state([sample[2] for sample in minibatch])
         rewards = torch.tensor([sample[3] for sample in minibatch], device=self.device).float()
         return (states, actions, next_states, rewards, weights)
+
+    def _make_state(self, states):
+        features = torch.cat([state.features for state in states])
+        done = torch.cat([state.done for state in states])
+        info = [state.info for state in states]
+        return State(features, done, info)
 
     def __len__(self):
         return len(self.buffer)

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -47,17 +47,11 @@ class ExperienceReplayBuffer(ReplayBuffer):
         self.pos = (self.pos + 1) % self.capacity
 
     def _reshape(self, minibatch, weights):
-        states = self._make_state([sample[0] for sample in minibatch])
+        states = State.from_list([sample[0] for sample in minibatch])
         actions = [sample[1] for sample in minibatch]
-        next_states = self._make_state([sample[2] for sample in minibatch])
+        next_states = State.from_list([sample[2] for sample in minibatch])
         rewards = torch.tensor([sample[3] for sample in minibatch], device=self.device).float()
         return (states, actions, next_states, rewards, weights)
-
-    def _make_state(self, states):
-        features = torch.cat([state.features for state in states])
-        done = torch.cat([state.done for state in states])
-        info = [state.info for state in states]
-        return State(features, done, info)
 
     def __len__(self):
         return len(self.buffer)

--- a/all/memory/replay_buffer_test.py
+++ b/all/memory/replay_buffer_test.py
@@ -77,7 +77,7 @@ class TestPrioritizedReplayBuffer(unittest.TestCase):
                 states[i], actions[i], states[i+1], rewards[i])
             if i > 2:
                 sample = self.replay_buffer.sample(3)
-                sample_states = torch.tensor(sample[0].features)
+                sample_states = sample[0].features
                 self.replay_buffer.update_priorities(torch.randn(3))
                 actual_samples.append(sample_states)
                 actual_weights.append(sample[-1])

--- a/all/presets/validate_agent.py
+++ b/all/presets/validate_agent.py
@@ -1,4 +1,5 @@
 import torch
+from all.environments import State
 from all.experiments import DummyWriter
 
 def validate_agent(make_agent, env):
@@ -17,7 +18,7 @@ def validate_single_env_agent(make_agent, env):
         env.step(agent.initial(env.state))
         while not env.done:
             env.step(agent.act(env.state, env.reward))
-        agent.terminal(env.reward)
+        agent.terminal(env.state, env.reward)
 
 def validate_multi_env_agent(make_agent, base_env):
     make, n_env = make_agent
@@ -28,7 +29,7 @@ def validate_multi_env_agent(make_agent, base_env):
         env.reset()
 
     for _ in range(10):
-        states = [env.state for env in envs]
+        states = State.from_list([env.state for env in envs])
         rewards = [env.reward for env in envs]
         rewards = torch.tensor(rewards, device=base_env.device).float()
         actions = agent.act(states, rewards)


### PR DESCRIPTION
Instead of State being a torch tensor, which is None in terminal state, make State a first-class object with the following properties:

```python
State {
    raw, # the raw tensor
    features, # feature tensor, used to make State dynamic
    done, # 0 if done, 1 otherwise. Careful!
    mask, # alias for done
    info # info object from environment
}
```

`State` also supports multi-env states, and fancy indexing.

There's still some work to do to really clean this up, but unit tests and linting pass.