### PR TITLE
Feature/experiment

### DIFF
--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .runner import SingleEnvRunner, ParallelEnvRunner
+from .writer import ExperimentWriter
 
 class Experiment:
     def __init__(
@@ -21,9 +22,12 @@ class Experiment:
         for env in envs:
             for agent in agents:
                 if isinstance(agent, tuple):
+                    agent_name = agent[0].__name__
                     runner = ParallelEnvRunner
                 else:
+                    agent_name = agent.__name__
                     runner = SingleEnvRunner
+
                 runner(
                     agent,
                     env,
@@ -31,5 +35,8 @@ class Experiment:
                     episodes=episodes,
                     render=render,
                     quiet=quiet,
-                    write_loss=write_loss,
+                    writer=self._make_writer(agent_name, env.name, write_loss),
                 )
+
+    def _make_writer(self, agent_name, env_name, write_loss):
+        return ExperimentWriter(agent_name, env_name, write_loss)

--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -1,123 +1,35 @@
-from timeit import default_timer as timer
 import numpy as np
-import torch
-from all.environments import GymEnvironment, State
-from .writer import ExperimentWriter
-
+from .runner import SingleEnvRunner, ParallelEnvRunner
 
 class Experiment:
-    def __init__(self, env, frames=None, episodes=None):
-        if frames is None:
-            frames = np.inf
-        if episodes is None:
-            episodes = np.inf
-        if isinstance(env, str):
-            self.env = GymEnvironment(env)
-        else:
-            self.env = env
-        self._max_frames = frames
-        self._max_episodes = episodes
-        self._agent = None
-        self._episode = None
-        self._frames = None
-        self._writer = None
-        self._render = None
-        self._console = None
-
-    def run(
+    def __init__(
             self,
-            make_agent,
-            label=None,
+            agents,
+            envs,
+            frames=np.inf,
+            episodes=np.inf,
             render=False,
-            console=True,
-            write_loss=True
+            quiet=False,
+            write_loss=True,
     ):
-        if isinstance(make_agent, tuple):
-            make, n_envs = make_agent
-            self._init_trial(make, label, render, console, write_loss)
-            self._run_multi(make, n_envs)
-        else:
-            self._init_trial(make_agent, label, render, console, write_loss)
-            self._run_single(make_agent)
+        if not isinstance(agents, list):
+            agents = [agents]
 
-    def _init_trial(self, make_agent, label, render, console, write_loss):
-        if label is None:
-            label = make_agent.__name__
-        self._frames = 0
-        self._episode = 1
-        self._render = render
-        self._console = console
-        self._writer = self._make_writer(label, write_loss)
+        if not isinstance(envs, list):
+            envs = [envs]
 
-    def _run_single(self, make_agent):
-        self._agent = make_agent(self.env, writer=self._writer)
-        while not self._done():
-            self._run_episode()
-
-    def _run_episode(self):
-        # setup
-        env = self.env
-        agent = self._agent
-        start = timer()
-        start_frames = self._frames
-        returns = 0
-
-        # run episode
-        env.reset()
-        while not env.done:
-            if self._render:
-                env.render()
-            env.step(agent.act(env.state, env.reward))
-            returns += env.reward
-            self._frames += 1
-            self._writer.frames = self._frames
-        agent.act(env.state, env.reward)
-
-        # cleanup and logging
-        end = timer()
-        fps = (self._frames - start_frames) / (end - start)
-        self._log(returns, fps)
-        self._episode += 1
-        self._writer.episodes = self._episode
-
-    def _run_multi(self, make_agent, n_envs):
-        envs = self.env.duplicate(n_envs)
-        agent = make_agent(envs, writer=self._writer)
         for env in envs:
-            env.reset()
-        returns = torch.zeros((n_envs)).float().to(self.env.device)
-        start = timer()
-        while not self._done():
-            states = State.from_list([env.state for env in envs])
-            rewards = torch.tensor([env.reward for env in envs]).float().to(self.env.device)
-            actions = agent.act(states, rewards)
-            for i, env in enumerate(envs):
-                if env.done:
-                    end = timer()
-                    fps = self._frames / (end - start)
-                    returns[i] += rewards[i]
-                    self._log(returns[i], fps)
-                    env.reset()
-                    returns[i] = 0
-                    self._episode += 1
-                    self._writer.episodes = self._episode
+            for agent in agents:
+                if isinstance(agent, tuple):
+                    runner = ParallelEnvRunner
                 else:
-                    if actions[i] is not None:
-                        returns[i] += rewards[i]
-                        env.step(actions[i])
-                        self._frames += 1
-                        self._writer.frames = self._frames
-
-    def _done(self):
-        return self._frames > self._max_frames or self._episode > self._max_episodes
-
-    def _log(self, returns, fps):
-        if self._console:
-            print("episode: %i, frames: %i, fps: %d, returns: %d" %
-                  (self._episode, self._frames, fps, returns))
-        self._writer.add_evaluation('returns-by-episode', returns, step="episode")
-        self._writer.add_evaluation('returns-by-frame', returns, step="frame")
-        self._writer.add_scalar('fps', fps, step="frame")
-
-    def _make_writer(self, label, write_loss):
-        return ExperimentWriter(label, self.env.name, loss=write_loss)
+                    runner = SingleEnvRunner
+                runner(
+                    agent,
+                    env,
+                    frames=frames,
+                    episodes=episodes,
+                    render=render,
+                    quiet=quiet,
+                    write_loss=write_loss,
+                )

--- a/all/experiments/experiment_test.py
+++ b/all/experiments/experiment_test.py
@@ -1,8 +1,11 @@
 import unittest
 import numpy as np
 import torch
-from all.presets.classic_control import dqn
+from all.presets.classic_control import dqn, a2c
+from all.environments import GymEnvironment
 from all.experiments import Experiment, Writer
+
+# pylint: disable=protected-access
 
 
 class MockWriter(Writer):
@@ -15,10 +18,7 @@ class MockWriter(Writer):
 
     def add_scalar(self, key, value, step="frame"):
         if not key in self.data:
-            self.data[key] = {
-                "values": [],
-                "steps": []
-            }
+            self.data[key] = {"values": [], "steps": []}
         self.data[key]["values"].append(value)
         self.data[key]["steps"].append(self._get_step(step))
 
@@ -26,7 +26,7 @@ class MockWriter(Writer):
         pass
 
     def add_evaluation(self, name, value, step="frame"):
-        self.add_scalar('evaluation/' + name, value, self._get_step(step))
+        self.add_scalar("evaluation/" + name, value, self._get_step(step))
 
     def _get_step(self, _type):
         if _type == "frame":
@@ -37,39 +37,43 @@ class MockWriter(Writer):
 
 
 class MockExperiment(Experiment):
-    def _make_writer(self, label, write_loss=True):
-        return MockWriter(label, write_loss)
-
-# pylint: disable=protected-access
+    def _make_writer(self, agent_name, env_name, write_loss):
+        self._writer = MockWriter(agent_name + '_' +  env_name, write_loss)
+        return self._writer
 
 
 class TestExperiment(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
         torch.manual_seed(0)
-        self.experiment = MockExperiment('CartPole-v0', episodes=3)
-        self.experiment.env.seed(0)
+        self.env = GymEnvironment('CartPole-v0')
+        self.env.seed(0)
+        self.experiment = None
 
     def test_adds_label(self):
-        self.experiment.run(dqn(), console=False)
-        self.assertEqual(self.experiment._writer.label, "_dqn")
+        experiment = MockExperiment(dqn(), self.env, quiet=True, episodes=3)
+        self.assertEqual(experiment._writer.label, "_dqn_CartPole-v0")
 
     def test_writes_returns_eps(self):
-        self.experiment.run(dqn(), console=False)
+        experiment = MockExperiment(dqn(), self.env, quiet=True, episodes=3)
         np.testing.assert_equal(
-            self.experiment._writer.data["evaluation/returns-by-episode"]["values"],
-            np.array([14., 19., 26.])
+            experiment._writer.data["evaluation/returns-by-episode"]["values"],
+            np.array([14.0, 19.0, 26.0]),
         )
         np.testing.assert_equal(
-            self.experiment._writer.data["evaluation/returns-by-episode"]["steps"],
-            np.array([1, 2, 3])
+            experiment._writer.data["evaluation/returns-by-episode"]["steps"],
+            np.array([1, 2, 3]),
         )
 
     def test_writes_loss(self):
-        self.experiment.run(dqn(), console=False)
-        self.assertTrue(self.experiment._writer.write_loss)
-        self.experiment.run(dqn(), console=False, write_loss=False)
-        self.assertFalse(self.experiment._writer.write_loss)
+        experiment = MockExperiment(dqn(), self.env, quiet=True, write_loss=True, episodes=3)
+        self.assertTrue(experiment._writer.write_loss)
+        experiment = MockExperiment(dqn(), self.env, quiet=True, write_loss=False, episodes=3)
+        self.assertFalse(experiment._writer.write_loss)
 
-if __name__ == '__main__':
+    def test_runs_multi_env(self):
+        experiment = MockExperiment(a2c(n_envs=3), self.env, quiet=True, episodes=3)
+        self.assertEqual(len(experiment._writer.data["evaluation/returns-by-episode"]["values"]), 3)
+
+if __name__ == "__main__":
     unittest.main()

--- a/all/experiments/runner.py
+++ b/all/experiments/runner.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from timeit import default_timer as timer
 import numpy as np
+import torch
+from all.environments import State
 from .writer import ExperimentWriter
 
 class EnvRunner(ABC):
@@ -8,14 +10,17 @@ class EnvRunner(ABC):
             self,
             agent,
             env,
+            agent_name=None,
+            env_name=None,
             frames=np.inf,
             episodes=np.inf,
             render=False,
             quiet=False,
             write_loss=True,
     ):
-        self._label = agent.__name__
         self._env = env
+        self._agent_name = agent_name or agent.__name__
+        self._env_name = env_name or self._env.name
         self._max_frames = frames
         self._max_episodes = episodes
         self._render = render
@@ -43,7 +48,7 @@ class EnvRunner(ABC):
         self._writer.add_scalar('fps', fps, step="frame")
 
     def _make_writer(self, write_loss):
-        return ExperimentWriter(self._label, self._env.name, loss=write_loss)
+        return ExperimentWriter(self._agent_name, self._env_name, loss=write_loss)
 
 class SingleEnvRunner(EnvRunner):
     def run(self):
@@ -78,5 +83,52 @@ class SingleEnvRunner(EnvRunner):
         return returns
 
 class ParallelEnvRunner(EnvRunner):
+    def __init__(self, agent, env, **kwargs):
+        make_agent, n_envs = agent
+        envs = env.duplicate(n_envs)
+        self._n_envs = n_envs
+        self._returns = None
+        self._start_time = None
+        super().__init__(make_agent, envs, env_name=env.name, **kwargs)
+
     def run(self):
-        pass
+        self._reset()
+        while not self._done():
+            self._step()
+
+    def _reset(self):
+        for env in self._env:
+            env.reset()
+        self._returns = torch.zeros(
+            (self._n_envs),
+            dtype=torch.float,
+            device=self._env[0].device
+        )
+        self._start_time = timer()
+
+    def _step(self):
+        states = State.from_list([env.state for env in self._env])
+        rewards = torch.tensor(
+            [env.reward for env in self._env],
+            dtype=torch.float,
+            device=self._env[0].device
+        )
+        actions = self._agent.act(states, rewards)
+
+        for i, env in enumerate(self._env):
+            self._step_env(i, env, actions[i])
+
+    def _step_env(self, i, env, action):
+        if env.done:
+            self._returns[i] += env.reward
+            end_time = timer()
+            fps = self._writer.frames / (end_time - self._start_time)
+            self._log(self._returns[i], fps)
+            env.reset()
+            self._returns[i] = 0
+            self._writer.episodes += 1
+        else:
+            if action is not None:
+                self._returns[i] += env.reward
+                env.step(action)
+                self._writer.frames += 1

--- a/all/experiments/runner.py
+++ b/all/experiments/runner.py
@@ -1,0 +1,82 @@
+from abc import ABC, abstractmethod
+from timeit import default_timer as timer
+import numpy as np
+from .writer import ExperimentWriter
+
+class EnvRunner(ABC):
+    def __init__(
+            self,
+            agent,
+            env,
+            frames=np.inf,
+            episodes=np.inf,
+            render=False,
+            quiet=False,
+            write_loss=True,
+    ):
+        self._label = agent.__name__
+        self._env = env
+        self._max_frames = frames
+        self._max_episodes = episodes
+        self._render = render
+        self._quiet = quiet
+        self._writer = self._make_writer(write_loss)
+        self._agent = agent(env, self._writer)
+        self.run()
+
+    @abstractmethod
+    def run(self):
+        pass
+
+    def _done(self):
+        return (
+            self._writer.frames > self._max_frames or 
+            self._writer.episodes > self._max_episodes
+        )
+
+    def _log(self, returns, fps):
+        if not self._quiet:
+            print("episode: %i, frames: %i, fps: %d, returns: %d" %
+                  (self._writer.episodes, self._writer.frames, fps, returns))
+        self._writer.add_evaluation('returns-by-episode', returns, step="episode")
+        self._writer.add_evaluation('returns-by-frame', returns, step="frame")
+        self._writer.add_scalar('fps', fps, step="frame")
+
+    def _make_writer(self, write_loss):
+        return ExperimentWriter(self._label, self._env.name, loss=write_loss)
+
+class SingleEnvRunner(EnvRunner):
+    def run(self):
+        while not self._done():
+            self._run_episode()
+
+    def _run_episode(self):
+        start_time = timer()
+        start_frames = self._writer.frames
+        returns = self._run_until_terminal_state()
+        end_time = timer()
+        fps = (self._writer.frames - start_frames) / (end_time - start_time)
+        self._log(returns, fps)
+        self._writer.episodes += 1
+
+    def _run_until_terminal_state(self):
+        agent = self._agent
+        env = self._env
+
+        env.reset()
+        returns = 0
+        action = agent.act(env.state, env.reward)
+
+        while not env.done:
+            self._writer.frames += 1
+            if self._render:
+                env.render()
+            env.step(action)
+            returns += env.reward
+            action = agent.act(env.state, env.reward)
+
+        return returns
+
+class ParallelEnvRunner(EnvRunner):
+    def run(self):
+        pass

--- a/all/experiments/slurm.py
+++ b/all/experiments/slurm.py
@@ -57,7 +57,7 @@ class SlurmExperiment:
     def run_experiment(self):
         task_id = int(os.environ['SLURM_ARRAY_TASK_ID'])
         env = self.envs[int(task_id / len(self.agents))]
-        agent = self.agents(task_id % len(self.agents))
+        agent = self.agents[task_id % len(self.agents)]
         Experiment(agent, env, frames=self.frames, write_loss=False)
 
     def queue_jobs(self):

--- a/demos/slurm_atari.py
+++ b/demos/slurm_atari.py
@@ -8,11 +8,8 @@ from all.experiments import SlurmExperiment
 from all.presets.atari import a2c
 from all.environments import AtariEnvironment
 
-# Quick demo of a2c running on slurm.
-# Note that it only runs for 1 million frames.
-# For real experiments, you will surely need a modified version of this script.
 device = 'cuda'
 envs = [AtariEnvironment(env, device) for env in ['Pong', 'Breakout', 'SpaceInvaders']]
-SlurmExperiment(a2c, envs, 1e6, hyperparameters={'device': device}, sbatch_args={
+SlurmExperiment(a2c(device=device), envs, 1e6, sbatch_args={
     'partition': '1080ti-short'
 })

--- a/demos/slurm_atari_full_suite.py
+++ b/demos/slurm_atari_full_suite.py
@@ -18,6 +18,6 @@ envs = [
     if 'NoFrameskip-v4' in env and not '-ram' in env
 ]
 
-SlurmExperiment(a2c, envs, 1e9, hyperparameters={'device': device}, sbatch_args={
+SlurmExperiment(a2c(device=device), envs, 1e9, sbatch_args={
     'partition': '1080ti-long' # long queue: run for a week
 })

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -3,29 +3,29 @@ from all.environments import AtariEnvironment
 from all.experiments import Experiment
 from all.presets import atari
 
+
 def run_atari():
-    parser = argparse.ArgumentParser(description='Run an Atari benchmark.')
-    parser.add_argument('env', help='Name of the Atari game (e.g. Pong)')
+    parser = argparse.ArgumentParser(description="Run an Atari benchmark.")
+    parser.add_argument("env", help="Name of the Atari game (e.g. Pong)")
     parser.add_argument(
-        'agent',
-        help="Name of the agent (e.g. dqn). See presets for available agents."
+        "agent", help="Name of the agent (e.g. dqn). See presets for available agents."
     )
     parser.add_argument(
-        '--device', default='cuda',
-        help='The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)'
+        "--device",
+        default="cuda",
+        help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
     )
-    parser.add_argument('--frames', type=int, default=200e6, help='The number of training frames')
+    parser.add_argument(
+        "--frames", type=int, default=200e6, help="The number of training frames"
+    )
     args = parser.parse_args()
 
     env = AtariEnvironment(args.env, device=args.device)
     agent_name = args.agent
     agent = getattr(atari, agent_name)
 
-    experiment = Experiment(
-        env,
-        frames=args.frames
-    )
-    experiment.run(agent(device=args.device), label=agent_name)
+    Experiment(agent(device=args.device), env, frames=args.frames)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_atari()

--- a/scripts/classic.py
+++ b/scripts/classic.py
@@ -3,7 +3,7 @@ from all.environments import GymEnvironment
 from all.experiments import Experiment
 from all.presets import classic_control
 
-def run_atari():
+def run_classic():
     parser = argparse.ArgumentParser(
         description='Run a classic control benchmark.')
     parser.add_argument('env', help='Name of the env (e.g. CartPole-v1)')
@@ -21,12 +21,12 @@ def run_atari():
     agent_name = args.agent
     agent = getattr(classic_control, agent_name)
 
-    experiment = Experiment(
+    Experiment(
+        agent(),
         env,
         episodes=args.episodes
     )
-    experiment.run(agent(device=args.device), label=agent_name)
 
 
 if __name__ == '__main__':
-    run_atari()
+    run_classic()

--- a/scripts/classic.py
+++ b/scripts/classic.py
@@ -3,17 +3,21 @@ from all.environments import GymEnvironment
 from all.experiments import Experiment
 from all.presets import classic_control
 
+
 def run_classic():
-    parser = argparse.ArgumentParser(
-        description='Run a classic control benchmark.')
-    parser.add_argument('env', help='Name of the env (e.g. CartPole-v1)')
+    parser = argparse.ArgumentParser(description="Run a classic control benchmark.")
+    parser.add_argument("env", help="Name of the env (e.g. CartPole-v1)")
     parser.add_argument(
-        'agent', help="Name of the agent (e.g. sarsa). See presets for available agents.")
-    parser.add_argument('--episodes', type=int, default=2000,
-                        help='The number of training frames')
+        "agent",
+        help="Name of the agent (e.g. sarsa). See presets for available agents.",
+    )
     parser.add_argument(
-        '--device', default='cuda',
-        help='The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)'
+        "--episodes", type=int, default=2000, help="The number of training frames"
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda",
+        help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
     )
     args = parser.parse_args()
 
@@ -21,12 +25,8 @@ def run_classic():
     agent_name = args.agent
     agent = getattr(classic_control, agent_name)
 
-    Experiment(
-        agent(),
-        env,
-        episodes=args.episodes
-    )
+    Experiment(agent(device=args.device), env, episodes=args.episodes)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_classic()

--- a/scripts/continuous.py
+++ b/scripts/continuous.py
@@ -7,28 +7,31 @@ from all.presets import continuous
 # some example envs
 # can also enter ID directly
 envs = {
-    'walker': 'BipedalWalker-v2',
-    'mountaincar': 'MountainCarContinuous-v0',
-    'lander': 'LunarLanderContinuous-v2',
-    'hopper': 'RoboschoolHopper-v1',
-    'cheetah': 'RoboschoolHalfCheetah-v1'
+    "walker": "BipedalWalker-v2",
+    "mountaincar": "MountainCarContinuous-v0",
+    "lander": "LunarLanderContinuous-v2",
+    "hopper": "RoboschoolHopper-v1",
+    "cheetah": "RoboschoolHalfCheetah-v1",
 }
 
+
 def run_atari():
-    parser = argparse.ArgumentParser(
-        description='Run a continuous actions benchmark.')
-    parser.add_argument('env', help='Name of the env (see envs)')
+    parser = argparse.ArgumentParser(description="Run a continuous actions benchmark.")
+    parser.add_argument("env", help="Name of the env (see envs)")
     parser.add_argument(
-        'agent', help="Name of the agent (e.g. actor_critic). See presets for available agents.")
-    parser.add_argument('--frames', type=int, default=2e6,
-                        help='The number of training frames')
-    parser.add_argument(
-        '--device', default='cuda',
-        help='The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)'
+        "agent",
+        help="Name of the agent (e.g. actor_critic). See presets for available agents.",
     )
     parser.add_argument(
-        '--render', default=False,
-        help='Whether to render the environment.'
+        "--frames", type=int, default=2e6, help="The number of training frames"
+    )
+    parser.add_argument(
+        "--device",
+        default="cuda",
+        help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
+    )
+    parser.add_argument(
+        "--render", default=False, help="Whether to render the environment."
     )
     args = parser.parse_args()
 
@@ -42,11 +45,9 @@ def run_atari():
     agent = getattr(continuous, agent_name)
 
     experiment = Experiment(
-        env,
-        frames=args.frames
+        agent(device=args.device), env, frames=args.frames, render=args.render
     )
-    experiment.run(agent(device=args.device), label=agent_name, render=args.render)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_atari()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -7,29 +7,33 @@ from all.presets import atari, classic_control, continuous
 # run on gpu
 device = 'cuda'
 
-# create slurm tasks for running classic control agents
-for agent_name in classic_control.__all__:
-    print('CartPole-v0,', agent_name)
-    agent = getattr(classic_control, agent_name)
-    envs = [GymEnvironment('CartPole-v0', device=device)]
-    SlurmExperiment(agent, envs, 100000, hyperparameters={'device': device}, sbatch_args={
-        'partition': '1080ti-short'
-    })
+def get_agents(preset):
+    agents = [getattr(preset, agent_name) for agent_name in classic_control.__all__]
+    return [agent(device=device) for agent in agents]
 
-# create slurm tasks for running atari agents
-for agent_name in atari.__all__:
-    print('Breakout', agent_name)
-    agent = getattr(atari, agent_name)
-    envs = [AtariEnvironment('Breakout', device=device)]
-    SlurmExperiment(agent, envs, 2e7, hyperparameters={'device': device}, sbatch_args={
+SlurmExperiment(
+    get_agents(atari),
+    AtariEnvironment('Breakout', device=device),
+    2e7,
+    sbatch_args={
         'partition': '1080ti-long'
-    })
+    }
+)
 
-# create slurm tasks for running atari agents
-for agent_name in continuous.__all__:
-    print('Lander', agent_name)
-    agent = getattr(continuous, agent_name)
-    envs = [GymEnvironment('LunarLanderContinuous-v2', device=device)]
-    SlurmExperiment(agent, envs, 500000, hyperparameters={'device': device}, sbatch_args={
+SlurmExperiment(
+    get_agents(classic_control),
+    GymEnvironment('CartPole-v0', device=device),
+    100000,
+    sbatch_args={
         'partition': '1080ti-short'
-    })
+    }
+)
+
+SlurmExperiment(
+    get_agents(continuous),
+    GymEnvironment('LunarLanderContinuous-v2', device=device),
+    500000,
+    sbatch_args={
+        'partition': '1080ti-short'
+    }
+)


### PR DESCRIPTION
#70 Make experiment accept both single agents and envs and lists of agents and envs. Remove the extra call to `.run()`, just run when the object is created.