### PR TITLE
Feature/lazy frames

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -436,7 +436,8 @@ good-names=i,
            lr,
            n,
            t,
-           e
+           e,
+           kl
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/all/agents/c51.py
+++ b/all/agents/c51.py
@@ -22,16 +22,16 @@ class C51(Agent):
     """
 
     def __init__(
-        self,
-        q_dist,
-        replay_buffer,
-        exploration=0.02,
-        discount_factor=0.99,
-        minibatch_size=32,
-        replay_start_size=5000,
-        update_frequency=1,
-        eps=1e-5, # stability parameter for loss
-        writer=DummyWriter(),
+            self,
+            q_dist,
+            replay_buffer,
+            exploration=0.02,
+            discount_factor=0.99,
+            minibatch_size=32,
+            replay_start_size=5000,
+            update_frequency=1,
+            eps=1e-5, # stability parameter for loss
+            writer=DummyWriter(),
     ):
         # objects
         self.q_dist = q_dist

--- a/all/agents/c51.py
+++ b/all/agents/c51.py
@@ -5,6 +5,7 @@ from ._agent import Agent
 
 torch.set_printoptions(threshold=10000)
 
+
 class C51(Agent):
     """
     Implementation of C51, a categorical DQN agent
@@ -21,15 +22,15 @@ class C51(Agent):
     """
 
     def __init__(
-            self,
-            q_dist,
-            replay_buffer,
-            exploration=0.02,
-            discount_factor=0.99,
-            minibatch_size=32,
-            replay_start_size=5000,
-            update_frequency=1,
-            writer=DummyWriter()
+        self,
+        q_dist,
+        replay_buffer,
+        exploration=0.02,
+        discount_factor=0.99,
+        minibatch_size=32,
+        replay_start_size=5000,
+        update_frequency=1,
+        writer=DummyWriter(),
     ):
         # objects
         self.q_dist = q_dist
@@ -60,7 +61,7 @@ class C51(Agent):
             self.replay_buffer.store(self.state, self.action, reward, state)
 
     def _choose_action(self, state):
-        if np.random.rand() < self.exploration:
+        if self._should_explore():
             return torch.randint(
                 self.q_dist.n_actions, (len(state),), device=self.q_dist.device
             )
@@ -68,16 +69,22 @@ class C51(Agent):
 
     def _train(self):
         if self._should_train():
-            (states, actions, rewards, next_states, weights) = self.replay_buffer.sample(
-                self.minibatch_size
-            )
+            (
+                states,
+                actions,
+                rewards,
+                next_states,
+                weights,
+            ) = self.replay_buffer.sample(self.minibatch_size)
             actions = torch.cat(actions)
             # choose best action from online network, double-q style
             next_actions = self._best_actions(next_states)
             # compute the distribution at the next state
             next_dist = self.q_dist.target(next_states, next_actions)
             # shift the atoms in the next distribution
-            shifted_atoms = (rewards.view((-1, 1)) + self.discount_factor * self.q_dist.atoms)
+            shifted_atoms = (
+                rewards.view((-1, 1)) + self.discount_factor * self.q_dist.atoms
+            )
             # project the disribution back on the original set of atoms
             target_dist = self.q_dist.project(next_dist, shifted_atoms)
             # apply update
@@ -86,17 +93,25 @@ class C51(Agent):
             loss.backward()
             self.q_dist.step()
             # useful for debugging
-            self.writer.add_loss('q_dist', loss.detach())
-            self.writer.add_loss('q_mean', (dist.detach() * self.q_dist.atoms).sum(dim=1).mean())
+            self.writer.add_loss("q_dist", loss.detach())
+            self.writer.add_loss(
+                "q_mean", (dist.detach() * self.q_dist.atoms).sum(dim=1).mean()
+            )
 
     def _best_actions(self, states):
         probs = self.q_dist.eval(states)
         q_values = (probs * self.q_dist.atoms).sum(dim=2)
         return torch.argmax(q_values, dim=1)
 
+    def _should_explore(self):
+        return (
+            len(self.replay_buffer) < self.replay_start_size
+            or np.random.rand() < self.exploration
+        )
+
     def _should_train(self):
         return (
-            self.frames_seen > self.replay_start_size
+            len(self.replay_buffer) >= self.replay_start_size
             and self.frames_seen % self.update_frequency == 0
         )
 

--- a/all/agents/ddqn.py
+++ b/all/agents/ddqn.py
@@ -57,8 +57,8 @@ class DDQN(Agent):
             next_actions = torch.argmax(self.q.eval(next_states), dim=1)
             targets = rewards + self.discount_factor * self.q.target(next_states, next_actions)
             td_errors = targets - self.q(states, actions)
+            self.replay_buffer.update_priorities(td_errors.abs())
             self.q.reinforce(weights * td_errors)
-            self.replay_buffer.update_priorities(td_errors)
 
     def _should_train(self):
         return (self.frames_seen > self.replay_start_size and

--- a/all/bodies/atari.py
+++ b/all/bodies/atari.py
@@ -3,7 +3,7 @@ from .rewards import ClipRewards
 from .vision import FrameStack
 
 class DeepmindAtariBody(Body):
-    def __init__(self, agent):
-        agent = FrameStack(agent)
+    def __init__(self, agent, lazy_frames=False):
+        agent = FrameStack(agent, lazy=lazy_frames)
         agent = ClipRewards(agent)
         super().__init__(agent)

--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -18,7 +18,7 @@ class FrameStack(Body):
         if self._lazy:
             state = LazyState(self._frames, state.mask, state.info)
         else:
-            state = State(torch.state(self._frames, dim=1), state.mask, state.info)
+            state = State(torch.cat(self._frames, dim=1), state.mask, state.info)
 
         return self.agent.act(state, reward)
 

--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -3,21 +3,29 @@ from all.environments import State
 from ._body import Body
 
 class FrameStack(Body):
-    def __init__(self, agent, size=4):
+    def __init__(self, agent, size=4, lazy=True):
         super().__init__(agent)
         self._frames = []
         self._size = size
+        self._lazy = lazy
 
     def act(self, state, reward):
         if not self._frames:
             self._frames = [state.raw] * self._size
         else:
             self._frames = self._frames[1:] + [state.raw]
-        return self.agent.act(
-            State(
-                torch.cat(self._frames, dim=1),
-                state.mask,
-                state.info
-            ),
-            reward
-        )
+
+        if self._lazy:
+            state = LazyState(self._frames, state.mask, state.info)
+        else:
+            state = State(torch.state(self._frames, dim=1), state.mask, state.info)
+
+        return self.agent.act(state, reward)
+
+class LazyState(State):
+    @property
+    def features(self):
+        return torch.cat(self._raw, dim=1)
+
+    def __len__(self):
+        return len(self._raw[0])

--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -3,7 +3,7 @@ from all.environments import State
 from ._body import Body
 
 class FrameStack(Body):
-    def __init__(self, agent, size=4, lazy=True):
+    def __init__(self, agent, size=4, lazy=False):
         super().__init__(agent)
         self._frames = []
         self._size = size

--- a/all/environments/state.py
+++ b/all/environments/state.py
@@ -18,7 +18,7 @@ class State:
 
     @classmethod
     def from_list(cls, states):
-        raw = torch.cat([state.raw for state in states])
+        raw = torch.cat([state.features for state in states])
         done = torch.cat([state.mask for state in states])
         info = sum([state.info for state in states], [])
         return cls(raw, done, info)

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -24,7 +24,7 @@ def c51(
         final_exploration_frame=1000000,
         final_exploration=0.02, # originally 0.1
         initial_exploration=1.,
-        lr=2.5e-4,
+        lr=1e-4,
         minibatch_size=32,
         replay_buffer_size=800000, # originally 1e6
         replay_start_size=50000,

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -18,18 +18,18 @@ def c51(
         # Taken from Extended Data Table 1
         # in https://www.nature.com/articles/nature14236
         # except where noted.
-        minibatch_size=32,
-        replay_buffer_size=100000, # originally 1e6
-        target_update_frequency=1000, # originally 1e4
-        discount_factor=0.99,
         action_repeat=4,
-        update_frequency=4,
-        lr=2.5e-4,  # requires slightly larger learning rate than dqn
-        eps=1.5e-4, # stability parameter for Adam
-        initial_exploration=1.,
-        final_exploration=0.02, # originally 0.1
+        discount_factor=0.99,
+        eps=1.5e-4,
         final_exploration_frame=1000000,
-        replay_start_size=10000,
+        final_exploration=0.02, # originally 0.1
+        initial_exploration=1.,
+        lr=2.5e-4,
+        minibatch_size=32,
+        replay_buffer_size=800000, # originally 1e6
+        replay_start_size=50000,
+        target_update_frequency=1000,
+        update_frequency=4,
         device=torch.device('cpu')
 ):
     # counted by number of updates rather than number of frame
@@ -74,6 +74,7 @@ def c51(
                 replay_start_size=replay_start_size,
                 update_frequency=update_frequency,
                 writer=writer
-            )
+            ),
+            lazy_frames=True
         )
     return _c51

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -21,7 +21,7 @@ def ddqn(
         initial_exploration=1.,
         lr=1e-4,
         minibatch_size=32,
-        replay_buffer_size=100000,
+        replay_buffer_size=800000,
         replay_start_size=50000,
         target_update_frequency=1000,
         update_frequency=4,

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -19,7 +19,7 @@ def ddqn(
         final_exploration_frame=1000000,
         final_exploration=0.02,
         initial_exploration=1.,
-        lr=2.5e-4,
+        lr=1e-4,
         minibatch_size=32,
         replay_buffer_size=100000,
         replay_start_size=50000,

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -13,23 +13,21 @@ from .models import nature_ddqn
 
 def ddqn(
         # vanilla DQN parameters
+        action_repeat=4,
+        discount_factor=0.99,
+        eps=1.5e-4,
+        final_exploration_frame=1000000,
+        final_exploration=0.02,
+        initial_exploration=1.,
+        lr=2.5e-4,
         minibatch_size=32,
         replay_buffer_size=100000,
-        agent_history_length=4,
-        target_update_frequency=1000,
-        discount_factor=0.99,
-        action_repeat=4,
-        update_frequency=4,
-        lr=2.5e-4,
-        eps=1.5e-4,
-        initial_exploration=1.,
-        final_exploration=0.02,
-        final_exploration_frame=1000000,
         replay_start_size=50000,
+        target_update_frequency=1000,
+        update_frequency=4,
         # Prioritized Replay
-        alpha=0.5,
-        beta=0.4,
-        final_beta_frame=200e6,
+        alpha=0.4,
+        beta=0.6,
         device=torch.device('cpu')
 ):
     '''
@@ -37,11 +35,9 @@ def ddqn(
     '''
     # counted by number of updates rather than number of frame
     final_exploration_frame /= action_repeat
-    replay_start_size /= action_repeat
-    final_beta_frame /= action_repeat
 
     def _ddqn(env, writer=DummyWriter()):
-        _model = nature_ddqn(env, frames=agent_history_length).to(device)
+        _model = nature_ddqn(env, frames=action_repeat).to(device)
         _optimizer = Adam(
             _model.parameters(),
             lr=lr,
@@ -80,5 +76,6 @@ def ddqn(
                  replay_start_size=replay_start_size,
                  update_frequency=update_frequency,
                 ),
+            lazy_frames=True
         )
     return _ddqn

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -1,6 +1,7 @@
 # /Users/cpnota/repos/autonomous-learning-library/all/approximation/value/action/torch.py
 import torch
 from torch.optim import Adam
+from torch.optim.lr_scheduler import CosineAnnealingLR
 from torch.nn.functional import smooth_l1_loss
 from all.approximation import QNetwork, FixedTarget
 from all.agents import DQN
@@ -28,22 +29,27 @@ def dqn(
         replay_start_size=50000,
         target_update_frequency=1000,
         update_frequency=4,
+        # other
+        last_frame=40e6,
         device=torch.device('cpu')
 ):
     # counted by number of updates rather than number of frame
     final_exploration_frame /= action_repeat
+    last_timestep = last_frame / action_repeat
+    last_update = last_timestep / update_frequency
 
     def _dqn(env, writer=DummyWriter()):
-        _model = nature_dqn(env).to(device)
-        _optimizer = Adam(
-            _model.parameters(),
+        model = nature_dqn(env).to(device)
+        optimizer = Adam(
+            model.parameters(),
             lr=lr,
             eps=eps
         )
         q = QNetwork(
-            _model,
-            _optimizer,
+            model,
+            optimizer,
             env.action_space.n,
+            scheduler=CosineAnnealingLR(optimizer, last_update),
             target=FixedTarget(target_update_frequency),
             loss=smooth_l1_loss,
             writer=writer

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -16,23 +16,22 @@ def dqn(
         # Taken from Extended Data Table 1
         # in https://www.nature.com/articles/nature14236
         # except where noted.
-        minibatch_size=32,
-        replay_buffer_size=100000, # originally 1e6
-        target_update_frequency=1000, # originally 1e4
-        discount_factor=0.99,
         action_repeat=4,
-        update_frequency=4,
-        lr=5e-4, # lr for Adam: Deepmind used RMSprop
-        eps=1.5e-4, # stability parameter for Adam
-        initial_exploration=1.,
-        final_exploration=0.02, # originally 0.1
+        discount_factor=0.99,
+        eps=1.5e-4,
         final_exploration_frame=1000000,
+        final_exploration=0.02, # originally 0.1
+        initial_exploration=1.,
+        lr=2.5e-4,
+        minibatch_size=32,
+        replay_buffer_size=800000, # originally 1 mil
         replay_start_size=50000,
+        target_update_frequency=1000,
+        update_frequency=4,
         device=torch.device('cpu')
 ):
     # counted by number of updates rather than number of frame
     final_exploration_frame /= action_repeat
-    replay_start_size /= action_repeat
 
     def _dqn(env, writer=DummyWriter()):
         _model = nature_dqn(env).to(device)
@@ -72,5 +71,6 @@ def dqn(
                 replay_start_size=replay_start_size,
                 update_frequency=update_frequency,
                 ),
+            lazy_frames=True
         )
     return _dqn

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -22,7 +22,7 @@ def dqn(
         final_exploration_frame=1000000,
         final_exploration=0.02, # originally 0.1
         initial_exploration=1.,
-        lr=2.5e-4,
+        lr=1e-4,
         minibatch_size=32,
         replay_buffer_size=800000, # originally 1 mil
         replay_start_size=50000,

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -18,7 +18,7 @@ def rainbow(
         lr=2.5e-4,  # requires slightly smaller learning rate than dqn
         minibatch_size=32,
         replay_buffer_size=200000, # choose as large as can fit on your cards
-        replay_start_size=20000, # in number of transitions
+        replay_start_size=5000, # in number of transitions
         target_update_frequency=1000,
         update_frequency=4,
         # explicit exploration in addition to noisy nets

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -15,7 +15,7 @@ def rainbow(
         # vanilla DQN parameters
         discount_factor=0.99,
         eps=1.5e-4, # stability parameter for Adam
-        lr=2.5e-4,  # requires slightly smaller learning rate than dqn
+        lr=1e-4,  # requires slightly smaller learning rate than dqn
         minibatch_size=32,
         replay_buffer_size=800000, # original of 1 million doesn't fit
         replay_start_size=50000, # in number of transitions

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -18,7 +18,7 @@ def rainbow(
         lr=2.5e-4,  # requires slightly smaller learning rate than dqn
         minibatch_size=32,
         replay_buffer_size=800000, # original of 1 million doesn't fit
-        replay_start_size=80000, # in number of transitions
+        replay_start_size=50000, # in number of transitions
         target_update_frequency=1000,
         update_frequency=4,
         # explicit exploration in addition to noisy nets

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -17,16 +17,16 @@ def rainbow(
         eps=1.5e-4, # stability parameter for Adam
         lr=2.5e-4,  # requires slightly smaller learning rate than dqn
         minibatch_size=32,
-        replay_buffer_size=200000, # choose as large as can fit on your cards
-        replay_start_size=5000, # in number of transitions
+        replay_buffer_size=800000, # original of 1 million doesn't fit
+        replay_start_size=80000, # in number of transitions
         target_update_frequency=1000,
         update_frequency=4,
         # explicit exploration in addition to noisy nets
         initial_exploration=0.02,
         final_exploration=0.,
         # prioritized replay
-        alpha=0.2, # priority scaling
-        beta=0.5,  # importance sampling adjustment
+        alpha=0.4, # priority scaling
+        beta=0.6,  # importance sampling adjustment
         # multi-step learning
         n_steps=3,
         # Distributional RL
@@ -51,7 +51,6 @@ def rainbow(
     6. Noisy nets
     '''
     action_repeat = 4
-    replay_start_size /= action_repeat
     last_timestep = last_frame / action_repeat
     last_update = last_timestep / update_frequency
 

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -93,6 +93,6 @@ def rainbow(
             update_frequency=update_frequency,
             writer=writer,
         )
-        return DeepmindAtariBody(agent)
+        return DeepmindAtariBody(agent, lazy_frames=True)
 
     return _rainbow


### PR DESCRIPTION
Add `LazyState` which allows for significant larger replay buffers (800k fit easily on my 8GB card, 1 mil should fit on gypsum). Tuned algorithms accordingly.

Also discovered some bugs with prioritized replay. `DDQN` was failing to take the absolute value of the TD error, so negative TD errors were being given minimum priority. `C51` was giving the cross entropy loss instead of the KL divergence as the priority, which has worse characteristics.