### PR TITLE
Feature/clean plots

### DIFF
--- a/all/experiments/plots.py
+++ b/all/experiments/plots.py
@@ -4,13 +4,13 @@ import matplotlib.pyplot as plt
 
 
 
-def plot_returns_100(runs_dir):
+def plot_returns_100(runs_dir, timesteps=-1):
     data = load_returns_100_data(runs_dir)
     lines = {}
     fig, axes = plt.subplots(1, len(data))
     for i, env in enumerate(sorted(data.keys())):
         ax = axes[i]
-        subplot_returns_100(ax, env, data[env], lines)
+        subplot_returns_100(ax, env, data[env], lines, timesteps=timesteps)
     fig.legend(list(lines.values()), list(lines.keys()), loc="center right")
     plt.show()
 
@@ -37,20 +37,23 @@ def load_returns_100_data(runs_dir):
     return data
 
 
-def subplot_returns_100(ax, env, data, lines):
+def subplot_returns_100(ax, env, data, lines, timesteps=-1):
     for agent in data:
         agent_data = data[agent]
-        timesteps = agent_data[:, 0]
+        x = agent_data[:, 0]
         mean = agent_data[:, 1]
         std = agent_data[:, 2]
 
+        if timesteps > 0:
+            x[-1] = timesteps
+
         if agent in lines:
-            ax.plot(timesteps, mean, label=agent, color=lines[agent].get_color())
+            ax.plot(x, mean, label=agent, color=lines[agent].get_color())
         else:
-            line, = ax.plot(timesteps, mean, label=agent)
+            line, = ax.plot(x, mean, label=agent)
             lines[agent] = line
         ax.fill_between(
-            timesteps, mean + std, mean - std, alpha=0.2, color=lines[agent].get_color()
+            x, mean + std, mean - std, alpha=0.2, color=lines[agent].get_color()
         )
         ax.set_title(env)
         ax.set_xlabel("timesteps")

--- a/all/experiments/plots.py
+++ b/all/experiments/plots.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
+
 def plot_returns_100(runs_dir):
     data = load_returns_100_data(runs_dir)
     lines = {}
@@ -53,3 +54,4 @@ def subplot_returns_100(ax, env, data, lines):
         )
         ax.set_title(env)
         ax.set_xlabel("timesteps")
+        ax.ticklabel_format(style='sci', axis='x', scilimits=(0, 5))

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -21,7 +21,7 @@ def a2c(
         # Other optimization settings
         clip_grad=0.5,
         entropy_loss_scaling=0.01,
-        value_loss_scaling=0.25,
+        value_loss_scaling=0.5,
         # Batch settings
         n_envs=16,
         n_steps=5,

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -5,8 +5,9 @@ from all.experiments import plot_returns_100
 def plot():
     parser = argparse.ArgumentParser(description="Plots the results of experiments.")
     parser.add_argument("dir", help="Output directory.")
+    parser.add_argument("--timesteps", type=int, default=-1, help="The final point will be fixed to this x-value")
     args = parser.parse_args()
-    plot_returns_100(args.dir)
+    plot_returns_100(args.dir, timesteps=args.timesteps)
 
 if __name__ == "__main__":
     plot()


### PR DESCRIPTION
Because of the fact that we are plotting the returns averaged over 100 episodes, the results may not end on exactly the same frame. This PR provides a feature to ensure that the final datapoint is placed on exactly the correct frame. This causes the generated plots to appear cleaner, at the expense of a small amount of accuracy.