### PR TITLE
add more readible datetime string that includes microseconds

### DIFF
--- a/all/experiments/writer.py
+++ b/all/experiments/writer.py
@@ -22,7 +22,7 @@ class ExperimentWriter(SummaryWriter, Writer):
     '''
     def __init__(self, experiment, agent_name, env_name, loss=True):
         self.env_name = env_name
-        current_time = datetime.now().strftime('%Y%m%d-%H%M%S')
+        current_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S %f')
         os.makedirs(
             os.path.join(
                 "runs", ("%s %s %s" % (agent_name, COMMIT_HASH, current_time)), env_name


### PR DESCRIPTION
Tweaking the datetime string that gets appended to each folder in `runs` to be more readible. Also, the microseconds are useful when a `SlurmExperiment` creates multiple runs in quick succession. This still isn't totally multi-process safe, but collisions are fairly unlikely.