### PR TITLE
Fix comma for python versions <= 3.5

### DIFF
--- a/all/approximation/q_dist.py
+++ b/all/approximation/q_dist.py
@@ -14,7 +14,7 @@ class QDist(Approximation):
             v_min,
             v_max,
             name="q_dist",
-            **kwargs,
+            **kwargs
     ):
         device = next(model.parameters()).device
         self.n_actions = n_actions


### PR DESCRIPTION
Python version <=3.5 do not work with trailing commas. See https://bugs.python.org/issue9232