### PR TITLE
Bugfix/ci

### DIFF
--- a/all/approximation/q_dist_test.py
+++ b/all/approximation/q_dist_test.py
@@ -131,7 +131,6 @@ class TestQDist(unittest.TestCase):
             torch.sign(new_probs - original_probs), torch.sign(target_dists - 0.5)
         )
 
-    # pylint: disable=bad-whitespace,bad-continuation
     def test_project_dist(self):
         # This gave problems in the past between different cuda version,
         # so a test was added.

--- a/all/bodies/rewards.py
+++ b/all/bodies/rewards.py
@@ -9,4 +9,4 @@ class ClipRewards(Body):
     def _clip(self, reward):
         if torch.is_tensor(reward):
             return torch.sign(reward)
-        return np.sign(reward)
+        return float(np.sign(reward))

--- a/all/nn/__init__.py
+++ b/all/nn/__init__.py
@@ -44,7 +44,7 @@ class Dueling(nn.Module):
     """
 
     def __init__(self, value_model, advantage_model):
-        super(Dueling, self).__init__()
+        super().__init__()
         self.value_model = value_model
         self.advantage_model = advantage_model
         self.aggregation = Aggregation()
@@ -59,7 +59,7 @@ class CategoricalDueling(nn.Module):
     """Dueling architecture for C51/Rainbow"""
 
     def __init__(self, value_model, advantage_model):
-        super(CategoricalDueling, self).__init__()
+        super().__init__()
         self.value_model = value_model
         self.advantage_model = advantage_model
 
@@ -98,7 +98,7 @@ class NoisyLinear(nn.Linear):
     """
 
     def __init__(self, in_features, out_features, sigma_init=0.017, bias=True):
-        super(NoisyLinear, self).__init__(in_features, out_features, bias=bias)
+        super().__init__(in_features, out_features, bias=bias)
         self.sigma_weight = nn.Parameter(
             torch.Tensor(out_features, in_features).fill_(sigma_init)
         )

--- a/all/presets/atari/models/test_.py
+++ b/all/presets/atari/models/test_.py
@@ -4,7 +4,7 @@ import torch_testing as tt
 from all.environments import AtariEnvironment
 from all.presets.atari.models import nature_rainbow
 
-# pylint: disable=bad-whitespace,bad-continuation
+
 class TestAtariModels(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(0)


### PR DESCRIPTION
Tests were failing in continuous integration. The source of the bug turned out to be that `ClipRewards` was producing a `double` instead of a `float`, which was causing errors in newer version of PyTorch.