### PR TITLE
Refactor/state array

### DIFF
--- a/all/__init__.py
+++ b/all/__init__.py
@@ -1,4 +1,4 @@
 import all.nn
-from all.core import State, StateTensor
+from all.core import State, StateArray
 
-__all__ = ['nn', 'State', 'StateTensor']
+__all__ = ['nn', 'State', 'StateArray']

--- a/all/agents/vpg.py
+++ b/all/agents/vpg.py
@@ -72,7 +72,7 @@ class VPG(Agent):
 
     def _terminal(self, state, reward):
         self._rewards.append(reward)
-        features = State.from_list(self._features)
+        features = State.array(self._features)
         rewards = torch.tensor(self._rewards, device=features.device)
         log_pis = torch.stack(self._log_pis)
         self._trajectories.append((features, rewards, log_pis))

--- a/all/approximation/q_dist_test.py
+++ b/all/approximation/q_dist_test.py
@@ -2,7 +2,7 @@ import unittest
 import torch
 from torch import nn
 import torch_testing as tt
-from all.core import StateTensor
+from all.core import StateArray
 from all.approximation import QDist
 
 STATE_DIM = 1
@@ -23,7 +23,7 @@ class TestQDist(unittest.TestCase):
         tt.assert_almost_equal(self.q.atoms, torch.tensor([-2, -1, 0, 1, 2]))
 
     def test_q_values(self):
-        states = StateTensor(torch.randn((3, STATE_DIM)), (3,))
+        states = StateArray(torch.randn((3, STATE_DIM)), (3,))
         probs = self.q(states)
         self.assertEqual(probs.shape, (3, ACTIONS, ATOMS))
         tt.assert_almost_equal(
@@ -53,7 +53,7 @@ class TestQDist(unittest.TestCase):
         )
 
     def test_single_q_values(self):
-        states = StateTensor(torch.randn((3, STATE_DIM)), (3,))
+        states = StateArray(torch.randn((3, STATE_DIM)), (3,))
         actions = torch.tensor([0, 1, 0])
         probs = self.q(states, actions)
         self.assertEqual(probs.shape, (3, ATOMS))
@@ -73,7 +73,7 @@ class TestQDist(unittest.TestCase):
         )
 
     def test_done(self):
-        states = StateTensor(torch.randn((3, STATE_DIM)), (3,), mask=torch.tensor([1, 0, 1]))
+        states = StateArray(torch.randn((3, STATE_DIM)), (3,), mask=torch.tensor([1, 0, 1]))
         probs = self.q(states)
         self.assertEqual(probs.shape, (3, ACTIONS, ATOMS))
         tt.assert_almost_equal(
@@ -100,7 +100,7 @@ class TestQDist(unittest.TestCase):
         )
 
     def test_reinforce(self):
-        states = StateTensor(torch.randn((3, STATE_DIM)), (3,))
+        states = StateArray(torch.randn((3, STATE_DIM)), (3,))
         actions = torch.tensor([0, 1, 0])
         original_probs = self.q(states, actions)
         tt.assert_almost_equal(

--- a/all/approximation/q_network_test.py
+++ b/all/approximation/q_network_test.py
@@ -4,7 +4,7 @@ from torch import nn
 from torch.nn.functional import smooth_l1_loss
 import torch_testing as tt
 import numpy as np
-from all.core import State, StateTensor
+from all.core import State, StateArray
 from all.approximation import QNetwork, FixedTarget
 
 STATE_DIM = 2
@@ -21,7 +21,7 @@ class TestQNetwork(unittest.TestCase):
         self.q = QNetwork(self.model, optimizer)
 
     def test_eval_list(self):
-        states = StateTensor(
+        states = StateArray(
             torch.randn(5, STATE_DIM),
             (5,),
             mask=torch.tensor([1, 1, 0, 1, 0])
@@ -40,7 +40,7 @@ class TestQNetwork(unittest.TestCase):
         )
 
     def test_eval_actions(self):
-        states = StateTensor(torch.randn(3, STATE_DIM), (3,))
+        states = StateArray(torch.randn(3, STATE_DIM), (3,))
         actions = [1, 2, 0]
         result = self.q.eval(states, actions)
         self.assertEqual(result.shape, torch.Size([3]))

--- a/all/approximation/v_network_test.py
+++ b/all/approximation/v_network_test.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn
 import torch_testing as tt
 from all.approximation.v_network import VNetwork
-from all.core import StateTensor
+from all.core import StateArray
 
 STATE_DIM = 2
 
@@ -22,7 +22,7 @@ class TestVNetwork(unittest.TestCase):
         self.v = VNetwork(self.model, optimizer)
 
     def test_reinforce_list(self):
-        states = StateTensor(
+        states = StateArray(
             torch.randn(5, STATE_DIM),
             (5,),
             mask=torch.tensor([1, 1, 0, 1, 0])
@@ -35,7 +35,7 @@ class TestVNetwork(unittest.TestCase):
         tt.assert_almost_equal(result, torch.tensor([0.9732854, 0.5453826, 0., 0.4344811, 0.]))
 
     def test_multi_reinforce(self):
-        states = StateTensor(
+        states = StateArray(
             torch.randn(6, STATE_DIM),
             (6,),
             mask=torch.tensor([1, 1, 0, 1, 0, 0, 0])

--- a/all/bodies/time.py
+++ b/all/bodies/time.py
@@ -1,5 +1,5 @@
 import torch
-from all.core import StateTensor
+from all.core import StateArray
 from ._body import Body
 
 class TimeFeature(Body):
@@ -9,7 +9,7 @@ class TimeFeature(Body):
         super().__init__(agent)
 
     def process_state(self, state):
-        if isinstance(state, StateTensor):
+        if isinstance(state, StateArray):
             if self.timestep is None:
                 self.timestep = torch.zeros(state.shape, device=state.device)
             observation = torch.cat((state.observation, self.scale * self.timestep.view(-1, 1)), dim=1)

--- a/all/bodies/time_test.py
+++ b/all/bodies/time_test.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 import torch_testing as tt
-from all.core import State, StateTensor
+from all.core import State, StateArray
 from all.bodies import TimeFeature
 
 
@@ -57,14 +57,14 @@ class TimeFeatureTest(unittest.TestCase):
             [0.3923, -0.2236, -0.3195, -1.2050, 1e-3]), atol=1e-04)
 
     def test_multi_env(self):
-        state = StateTensor(torch.randn(2, 2), (2,))
+        state = StateArray(torch.randn(2, 2), (2,))
         self.agent.act(state)
         tt.assert_allclose(self.test_agent.last_state.observation, torch.tensor(
             [[0.3923, -0.2236, 0.], [-0.3195, -1.2050, 0.]]), atol=1e-04)
         self.agent.act(state)
         tt.assert_allclose(self.test_agent.last_state.observation, torch.tensor(
             [[0.3923, -0.2236, 1e-3], [-0.3195, -1.2050, 1e-3]]), atol=1e-04)
-        self.agent.act(StateTensor(state.observation, (2,), done=torch.tensor([False, True])))
+        self.agent.act(StateArray(state.observation, (2,), done=torch.tensor([False, True])))
         tt.assert_allclose(self.test_agent.last_state.observation, torch.tensor(
             [[0.3923, -0.2236, 2e-3], [-0.3195, -1.2050, 2e-3]]), atol=1e-04)
         self.agent.act(state)

--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -1,5 +1,5 @@
 import torch
-from all.core import State, StateTensor
+from all.core import State, StateArray
 from ._body import Body
 
 class FrameStack(Body):
@@ -16,7 +16,7 @@ class FrameStack(Body):
             self._frames = self._frames[1:] + [state.observation]
         if self._lazy:
             return LazyState.from_state(state, self._frames)
-        if isinstance(state, StateTensor):
+        if isinstance(state, StateArray):
             return state.update('observation', torch.cat(self._frames, dim=1))
         return state.update('observation', torch.cat(self._frames, dim=0))
 

--- a/all/core/__init__.py
+++ b/all/core/__init__.py
@@ -1,3 +1,3 @@
-from .state import State, StateTensor
+from .state import State, StateArray
 
-__all__ = ['State', 'StateTensor']
+__all__ = ['State', 'StateArray']

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -22,7 +22,7 @@ class State(dict):
         self.device = device
 
     @classmethod
-    def from_list(cls, list_of_states):
+    def array(cls, list_of_states):
         device = list_of_states[0].device
         shape = (len(list_of_states), *list_of_states[0].shape)
         x = {}

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -12,12 +12,23 @@ class State(dict):
     masking the output of networks based on the done flag, etc.
 
     Args:
-        x (dict): A dictionary containing all state information. Any key/value can be included, but the following keys are standard:
-            observation (torch.tensor) (required): Rea torch.tensor representing the current state
-            reward (float) (optional): The reward for the previous state/action. Defaults to 0.
-            done (bool) (optional): Whether or not this is a terminal state. Defaults to False.
-            mask (float) (optional): The mask (0 or 1) for the current state. Defaults to 0 if terminal state, 1 otherwise.
-        device (string): The torch device on which component tensors are stored.
+        x (dict):
+            A dictionary containing all state information.
+            Any key/value can be included, but the following keys are standard:
+
+            observation (torch.tensor) (required):
+                A tensor representing the current state
+
+            reward (float) (optional):
+                The reward for the previous state/action. Defaults to 0.
+
+            done (bool) (optional):
+                Whether or not this is a terminal state. Defaults to False.
+
+            mask (float) (optional):
+                The mask (0 or 1) for the current state.
+        device (string):
+            The torch device on which component tensors are stored.
     """
     def __init__(self, x, device='cpu', **kwargs):
         if not isinstance(x, dict):
@@ -69,9 +80,11 @@ class State(dict):
         Automatically selects the correct keys, reshapes the input/output as necessary and applies the mask.
 
         Args:
-            model (torch.nn.Module): A torch Module which accepts the components corresponding to the given keys as args.
+            model (torch.nn.Module): A torch Module which accepts the components corresponding
+                                     to the given keys as args.
             keys (string): Strings corresponding to the desired components of the state.
-                E.g., apply(model, 'observation', 'reward') would pass the observation and reward as arguments to the model.
+                           E.g., apply(model, 'observation', 'reward') would pass the observation
+                           and reward as arguments to the model.
 
         Returns:
             The output of the model.
@@ -175,18 +188,22 @@ class State(dict):
 
     @property
     def observation(self):
+        """A tensor containing the current observation."""
         return self['observation']
 
     @property
     def reward(self):
+        """A float representing the reward for the previous state/action pair."""
         return self['reward']
 
     @property
     def done(self):
+        """A boolean that is true if the state is a terminal state, and false otherwise."""
         return self['done']
 
     @property
     def mask(self):
+        """A float that is 1. if the state is non-terminal, or 0. otherwise."""
         return self['mask']
 
     def __len__(self):

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -45,7 +45,7 @@ class State(dict):
         if 'mask' not in x:
             x['mask'] = 1. - x['done']
         super().__init__(x)
-        self.shape = ()
+        self._shape = ()
         self.device = device
 
     @classmethod
@@ -206,6 +206,11 @@ class State(dict):
     def mask(self):
         """A float that is 1. if the state is non-terminal, or 0. otherwise."""
         return self['mask']
+
+    @property
+    def shape(self):
+        """The shape of the State or StateArray. A State always has shape ()."""
+        return self._shape
 
     def __len__(self):
         return 1

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -138,26 +138,26 @@ class StateArrayTest(unittest.TestCase):
         tt.assert_equal(state.mask, torch.tensor([0., 1., 0.]))
 
     def test_multi_dim(self):
-        state = StateArray.from_list([
+        state = StateArray.array([
             State(torch.randn((3, 4))),
             State(torch.randn((3, 4)))
         ])
         self.assertEqual(state.shape, (2,))
-        state = StateArray.from_list([state] * 3)
+        state = StateArray.array([state] * 3)
         self.assertEqual(state.shape, (3, 2))
-        state = StateArray.from_list([state] * 5)
+        state = StateArray.array([state] * 5)
         self.assertEqual(state.shape, (5, 3, 2))
         tt.assert_equal(state.mask, torch.ones((5, 3, 2)))
         tt.assert_equal(state.done, torch.zeros((5, 3, 2)).bool())
         tt.assert_equal(state.reward, torch.zeros((5, 3, 2)))
 
     def test_view(self):
-        state = StateArray.from_list([
+        state = StateArray.array([
             State(torch.randn((3, 4))),
             State(torch.randn((3, 4)))
         ])
         self.assertEqual(state.shape, (2,))
-        state = StateArray.from_list([state] * 3)
+        state = StateArray.array([state] * 3)
         self.assertEqual(state.shape, (3, 2))
         state = state.view((2, 3))
         self.assertEqual(state.shape, (2, 3))

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import torch
 import torch_testing as tt
-from all.core import State, StateTensor
+from all.core import State, StateArray
 
 class StateTest(unittest.TestCase):
     def test_constructor_defaults(self):
@@ -97,7 +97,7 @@ class StateTest(unittest.TestCase):
         self.assertEqual(output.shape, (5, 3))
         self.assertEqual(output.sum().item(), 0)
 
-class StateTensorTest(unittest.TestCase):
+class StateArrayTest(unittest.TestCase):
     def test_constructor_defaults(self):
         raw = torch.randn(3, 4)
         state = State(raw, (3,))
@@ -108,7 +108,7 @@ class StateTensorTest(unittest.TestCase):
 
     def test_apply(self):
         observation = torch.randn(3, 4)
-        state = StateTensor(observation, (3,))
+        state = StateArray(observation, (3,))
         model = torch.nn.Linear(4, 2)
         output = state.apply(model, 'observation')
         self.assertEqual(output.shape, (3, 2))
@@ -116,7 +116,7 @@ class StateTensorTest(unittest.TestCase):
 
     def test_apply_done(self):
         observation = torch.randn(3, 4)
-        state = StateTensor(observation, (3,), mask=torch.tensor([0., 0., 0.]))
+        state = StateArray(observation, (3,), mask=torch.tensor([0., 0., 0.]))
         model = torch.nn.Linear(4, 2)
         output = state.apply(model, 'observation')
         self.assertEqual(output.shape, (3, 2))
@@ -125,39 +125,39 @@ class StateTensorTest(unittest.TestCase):
 
     def test_as_output(self):
         observation = torch.randn(3, 4)
-        state = StateTensor(observation, (3,))
+        state = StateArray(observation, (3,))
         tensor = torch.randn(3, 5)
         self.assertEqual(state.as_output(tensor).shape, (3, 5))
 
     def test_auto_mask(self):
         observation = torch.randn(3, 4)
-        state = StateTensor({
+        state = StateArray({
             'observation': observation,
             'done': torch.tensor([True, False, True]),
         }, (3,))
         tt.assert_equal(state.mask, torch.tensor([0., 1., 0.]))
 
     def test_multi_dim(self):
-        state = StateTensor.from_list([
+        state = StateArray.from_list([
             State(torch.randn((3, 4))),
             State(torch.randn((3, 4)))
         ])
         self.assertEqual(state.shape, (2,))
-        state = StateTensor.from_list([state] * 3)
+        state = StateArray.from_list([state] * 3)
         self.assertEqual(state.shape, (3, 2))
-        state = StateTensor.from_list([state] * 5)
+        state = StateArray.from_list([state] * 5)
         self.assertEqual(state.shape, (5, 3, 2))
         tt.assert_equal(state.mask, torch.ones((5, 3, 2)))
         tt.assert_equal(state.done, torch.zeros((5, 3, 2)).bool())
         tt.assert_equal(state.reward, torch.zeros((5, 3, 2)))
 
     def test_view(self):
-        state = StateTensor.from_list([
+        state = StateArray.from_list([
             State(torch.randn((3, 4))),
             State(torch.randn((3, 4)))
         ])
         self.assertEqual(state.shape, (2,))
-        state = StateTensor.from_list([state] * 3)
+        state = StateArray.from_list([state] * 3)
         self.assertEqual(state.shape, (3, 2))
         state = state.view((2, 3))
         self.assertEqual(state.shape, (2, 3))

--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -132,7 +132,7 @@ class ParallelEnvExperiment(Experiment):
                     env.step(action)
 
     def _aggregate_states(self):
-        return State.from_list([env.state for env in self._envs])
+        return State.array([env.state for env in self._envs])
 
     def _aggregate_rewards(self):
         return torch.tensor(

--- a/all/memory/advantage.py
+++ b/all/memory/advantage.py
@@ -92,9 +92,9 @@ class NStepAdvantageBuffer:
                     next_state = state
 
         return (
-            State.from_list(sample_states),
+            State.array(sample_states),
             torch.stack(sample_actions),
-            State.from_list(sample_next_states)
+            State.array(sample_next_states)
         )
 
     def _compute_advantages(self, states, rewards, next_states, lengths):

--- a/all/memory/advantage_test.py
+++ b/all/memory/advantage_test.py
@@ -2,7 +2,7 @@ import unittest
 import torch
 import torch_testing as tt
 from all import nn
-from all.core import StateTensor
+from all.core import StateArray
 from all.approximation import VNetwork, FeatureNetwork
 from all.memory import NStepAdvantageBuffer
 
@@ -23,13 +23,13 @@ class NStepAdvantageBufferTest(unittest.TestCase):
     def test_rollout(self):
         buffer = NStepAdvantageBuffer(self.v, self.features, 2, 3, discount_factor=0.5)
         actions = torch.ones((3))
-        states = StateTensor(torch.arange(0, 12).unsqueeze(1).float(), (12,))
+        states = StateArray(torch.arange(0, 12).unsqueeze(1).float(), (12,))
         buffer.store(states[0:3], actions, torch.zeros(3))
         buffer.store(states[3:6], actions, torch.ones(3))
         states, _, advantages = buffer.advantages(states[6:9])
 
-        expected_states = StateTensor(torch.arange(0, 6).unsqueeze(1).float(), (6,))
-        expected_next_states = StateTensor(
+        expected_states = StateArray(torch.arange(0, 6).unsqueeze(1).float(), (6,))
+        expected_next_states = StateArray(
             torch.cat((torch.arange(6, 9), torch.arange(6, 9))).unsqueeze(1).float(), (6,)
         )
         expected_returns = torch.tensor([
@@ -53,19 +53,19 @@ class NStepAdvantageBufferTest(unittest.TestCase):
         done[5] = True
         done[7] = True
         done[9] = True
-        states = StateTensor(torch.arange(0, 12).unsqueeze(1).float(), (12,), done=done)
+        states = StateArray(torch.arange(0, 12).unsqueeze(1).float(), (12,), done=done)
         actions = torch.ones((3))
         buffer.store(states[0:3], actions, torch.zeros(3))
         buffer.store(states[3:6], actions, torch.ones(3))
         buffer.store(states[6:9], actions, 2 * torch.ones(3))
         states, actions, advantages = buffer.advantages(states[9:12])
 
-        expected_states = StateTensor(torch.arange(0, 9).unsqueeze(1).float(), (9,), done=done[0:9])
+        expected_states = StateArray(torch.arange(0, 9).unsqueeze(1).float(), (9,), done=done[0:9])
         expected_next_done = torch.tensor([True] * 9)
         expected_next_done[5] = False
         expected_next_done[7] = False
         expected_next_done[8] = False
-        expected_next_states = StateTensor(torch.tensor([
+        expected_next_states = StateArray(torch.tensor([
             9, 7, 5,
             9, 7, 11,
             9, 10, 11
@@ -88,15 +88,15 @@ class NStepAdvantageBufferTest(unittest.TestCase):
 
     def test_multi_rollout(self):
         buffer = NStepAdvantageBuffer(self.v, self.features, 2, 2, discount_factor=0.5)
-        raw_states = StateTensor(torch.arange(0, 12).unsqueeze(1).float(), (12,))
+        raw_states = StateArray(torch.arange(0, 12).unsqueeze(1).float(), (12,))
         actions = torch.ones((2))
         buffer.store(raw_states[0:2], actions, torch.ones(2))
         buffer.store(raw_states[2:4], actions, torch.ones(2))
 
         states, actions, advantages = buffer.advantages(raw_states[4:6])
-        expected_states = StateTensor(torch.arange(0, 4).unsqueeze(1).float(), (4,))
+        expected_states = StateArray(torch.arange(0, 4).unsqueeze(1).float(), (4,))
         expected_returns = torch.tensor([1.5, 1.5, 1, 1])
-        expected_next_states = StateTensor(torch.tensor([4., 5, 4, 5]).unsqueeze(1), (4,))
+        expected_next_states = StateArray(torch.tensor([4., 5, 4, 5]).unsqueeze(1), (4,))
         expected_lengths = torch.tensor([2., 2, 1, 1])
         self.assert_states_equal(states, expected_states)
         tt.assert_allclose(advantages, self._compute_expected_advantages(
@@ -110,12 +110,12 @@ class NStepAdvantageBufferTest(unittest.TestCase):
         buffer.store(raw_states[6:8], actions, torch.ones(2))
 
         states, actions, advantages = buffer.advantages(raw_states[8:10])
-        expected_states = StateTensor(torch.arange(4, 8).unsqueeze(1).float(), (4,))
+        expected_states = StateArray(torch.arange(4, 8).unsqueeze(1).float(), (4,))
         self.assert_states_equal(states, expected_states)
         tt.assert_allclose(advantages, self._compute_expected_advantages(
             expected_states,
             torch.tensor([1.5, 1.5, 1, 1]),
-            StateTensor(torch.tensor([8, 9, 8, 9]).unsqueeze(1).float(), (4,)),
+            StateArray(torch.tensor([8, 9, 8, 9]).unsqueeze(1).float(), (4,)),
             torch.tensor([2., 2, 1, 1])
         ))
 

--- a/all/memory/generalized_advantage.py
+++ b/all/memory/generalized_advantage.py
@@ -44,7 +44,7 @@ class GeneralizedAdvantageBuffer:
             raise Exception("Not enough states received!")
 
         self._states.append(states)
-        states = State.from_list(self._states[0:self.n_steps + 1])
+        states = State.array(self._states[0:self.n_steps + 1])
         actions = torch.cat(self._actions[:self.n_steps], dim=0)
         rewards = torch.stack(self._rewards[:self.n_steps])
         _values = self.v.target(self.features.target(states))

--- a/all/memory/generalized_advantage_test.py
+++ b/all/memory/generalized_advantage_test.py
@@ -30,7 +30,7 @@ class GeneralizedAdvantageBufferTest(unittest.TestCase):
             lam=0.5
         )
         actions = torch.ones((1))
-        states = State.from_list([State({'observation': torch.tensor([float(x)])}) for x in range(3)])
+        states = State.array([State({'observation': torch.tensor([float(x)])}) for x in range(3)])
         rewards = torch.tensor([1., 2, 4])
         buffer.store(states[0], actions, rewards[0])
         buffer.store(states[1], actions, rewards[1])
@@ -64,12 +64,12 @@ class GeneralizedAdvantageBufferTest(unittest.TestCase):
         actions = torch.ones((2))
 
         def make_states(x, y):
-            return State.from_list([
+            return State.array([
                 State({'observation': torch.tensor([float(x)])}),
                 State({'observation': torch.tensor([float(y)])})
             ])
 
-        states = State.from_list([
+        states = State.array([
             make_states(0, 3),
             make_states(1, 4),
             make_states(2, 5),

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -48,12 +48,12 @@ class ExperienceReplayBuffer(ReplayBuffer):
         self.pos = (self.pos + 1) % self.capacity
 
     def _reshape(self, minibatch, weights):
-        states = State.from_list([sample[0] for sample in minibatch])
+        states = State.array([sample[0] for sample in minibatch])
         if torch.is_tensor(minibatch[0][1]):
             actions = torch.stack([sample[1] for sample in minibatch])
         else:
             actions = torch.tensor([sample[1] for sample in minibatch], device=self.device)
-        next_states = State.from_list([sample[2] for sample in minibatch])
+        next_states = State.array([sample[2] for sample in minibatch])
         return (states, actions, next_states.reward, next_states, weights)
 
     def __len__(self):

--- a/all/memory/replay_buffer_test.py
+++ b/all/memory/replay_buffer_test.py
@@ -3,7 +3,7 @@ import random
 import torch
 import numpy as np
 import torch_testing as tt
-from all.core import State, StateTensor
+from all.core import State, StateArray
 from all.memory import (
     ExperienceReplayBuffer,
     PrioritizedReplayBuffer,
@@ -60,7 +60,7 @@ class TestPrioritizedReplayBuffer(unittest.TestCase):
         self.replay_buffer = PrioritizedReplayBuffer(5, 0.6)
 
     def test_run(self):
-        states = StateTensor(torch.arange(0, 20), (20,), reward=torch.arange(-1, 19).float())
+        states = StateArray(torch.arange(0, 20), (20,), reward=torch.arange(-1, 19).float())
         actions = torch.arange(0, 20).view((-1, 1))
         expected_samples = State(
             torch.tensor(
@@ -114,7 +114,7 @@ class TestNStepReplayBuffer(unittest.TestCase):
         self.replay_buffer = NStepReplayBuffer(4, 0.5, ExperienceReplayBuffer(100))
 
     def test_run(self):
-        states = StateTensor(torch.arange(0, 20), (20,), reward=torch.arange(-1, 19).float())
+        states = StateArray(torch.arange(0, 20), (20,), reward=torch.arange(-1, 19).float())
         actions = torch.arange(0, 20)
 
         for i in range(3):

--- a/all/nn/nn_test.py
+++ b/all/nn/nn_test.py
@@ -4,7 +4,7 @@ import torch
 import torch_testing as tt
 import gym
 from all import nn
-from all.core import StateTensor
+from all.core import StateArray
 
 
 class TestNN(unittest.TestCase):
@@ -36,7 +36,7 @@ class TestNN(unittest.TestCase):
         net = nn.RLNetwork(model, (2,))
         features = torch.randn((4, 2))
         done = torch.tensor([False, False, True, False])
-        out = net(StateTensor(features, (4,), done=done))
+        out = net(StateArray(features, (4,), done=done))
         tt.assert_almost_equal(
             out,
             torch.tensor(
@@ -51,7 +51,7 @@ class TestNN(unittest.TestCase):
 
         features = torch.randn(3, 2)
         done = torch.tensor([False, False, False])
-        out = net(StateTensor(features, (3,), done=done))
+        out = net(StateArray(features, (3,), done=done))
         tt.assert_almost_equal(
             out,
             torch.tensor(

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ Enjoy!
     modules/agents
     modules/approximation
     modules/bodies
+    modules/core
     modules/environments
     modules/experiments
     modules/logging

--- a/docs/source/modules/core.rst
+++ b/docs/source/modules/core.rst
@@ -1,0 +1,10 @@
+.. _core:
+
+
+all.core
+=================
+
+.. automodsumm:: all.core
+
+.. automodule:: all.core
+    :members:


### PR DESCRIPTION
Reflecting on a conversation with @mctigger found [here](https://github.com/cpnota/autonomous-learning-library/pull/160), I decided the best name for the object representing an array of states was `StateArray`, not `StateTensor`, as using "Tensor" in this way is a sort of a misapplication of the term (in fact, it's not strictly accurate to call the central entity in `PyTorch` a "tensor" either, but it's for convenience). `StateArray` is more correct and gets the point across.

Also adding some documentation as part of this PR (in progress).