### PR TITLE
Only apply the Atari FireReset wrapper to supported games.

### DIFF
--- a/all/environments/atari.py
+++ b/all/environments/atari.py
@@ -19,7 +19,8 @@ class AtariEnvironment(GymEnvironment):
         # apply a subset of wrappers
         env = NoopResetEnv(env, noop_max=30)
         env = MaxAndSkipEnv(env)
-        env = FireResetEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
         env = WarpFrame(env)
         env = LifeLostEnv(env)
         # initialize


### PR DESCRIPTION
This is akin to [this check](https://github.com/openai/baselines/blob/7c520852d9cf4eaaad326a3d548efc915dc60c10/baselines/common/atari_wrappers.py#L280) in the baselines repo.

The following Atari environments do not have a FIRE action and now work:
KungFuMaster, Freeway, Skiing, Tutankham, JourneyEscape, MsPacman, and Asterix.