### PR TITLE
fix sac eval mode

### DIFF
--- a/all/agents/sac.py
+++ b/all/agents/sac.py
@@ -71,7 +71,7 @@ class SAC(Agent):
         return self._action
 
     def eval(self, state):
-        return self.policy.eval(state)[0]
+        return self.policy.eval(state)
 
     def _train(self):
         if self._should_train():

--- a/all/presets/continuous_test.py
+++ b/all/presets/continuous_test.py
@@ -14,7 +14,7 @@ class TestContinuousPresets(unittest.TestCase):
         self.validate(sac(replay_start_size=50, device='cpu'))
 
     def validate(self, make_agent):
-        validate_agent(make_agent, GymEnvironment('Pendulum-v0'))
+        validate_agent(make_agent, GymEnvironment('LunarLanderContinuous-v2'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ended up going with a different fix for #165 in order to be slightly more consistent with the other policies in eval mode. In training mode, the SAC policy class returns an `action` and the `log_prob` of that action (or a batch of each). The eval mode, it just returns the `action`. This is conceptually consistent with the other policies, which return a `Distribution` in training mode and an `action` in eval mode.

The bug was that the `SAC` agent was still treating the return value of the policy as a tuple, `(action, log_prob)`, and therefore was inappropriately indexing into its return value. If the action only had 1-dimension, this still worked, so the `Pendulum` test run by the continuous integration failed to catch this bug. This PR changes the test to use `LunarLanderContinuous-v2` instead.