### PR TITLE
Hotfix: Pass dtype to State.from_gym()

### DIFF
--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -39,11 +39,15 @@ class GymEnvironment(Environment):
         return self._name
 
     def reset(self):
-        self._state = State.from_gym(self._env.reset(), device=self._device)
+        self._state = State.from_gym(self._env.reset(), dtype=self._env.observation_space.dtype, device=self._device)
         return self._state
 
     def step(self, action):
-        self._state = State.from_gym(self._env.step(self._convert(action)), device=self._device)
+        self._state = State.from_gym(
+            self._env.step(self._convert(action)),
+            dtype=self._env.observation_space.dtype,
+            device=self._device
+        )
         return self._state
 
     def render(self, **kwargs):


### PR DESCRIPTION
State.from_gym() accepts an optional `dtype` for the observation, but defaults to `float`. For Atari, the dtype should be `uint8` in order to use less memory. The dtype was not being passed, meaning that the 1 million frame replay buffer would no longer fit on many graphics cards.