### PR TITLE
Add all current versions of Python to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,17 +39,3 @@ jobs:
     script:
       - make lint
       - make test
-
-  - name "Python 3.9 on Linux"
-    python: 3.9
-    branches:
-      only:
-        - master
-        - develop
-    install:
-      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - pip install -q -e .["dev"]
-    script:
-      - make lint
-      - make test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,15 @@
 language: python
-
-jobs:
-  - name "Python 3.6 on Linux"
-    python: 3.6
-    branches:
-      only:
-        - master
-        - develop
-    install:
-      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - pip install -q -e .["dev"]
-    script:
-      - make lint
-      - make test
-
-  - name "Python 3.7 on Linux"
-    python: 3.7
-    branches:
-      only:
-        - master
-        - develop
-    install:
-      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - pip install -q -e .["dev"]
-    script:
-      - make lint
-      - make test
-
-  - name "Python 3.8 on Linux"
-    python: 3.8
-    branches:
-      only:
-        - master
-        - develop
-    install:
-      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - pip install -q -e .["dev"]
-    script:
-      - make lint
-      - make test
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+branches:
+  only:
+  - master
+  - develop
+install:
+  - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+  - pip install -q -e .["dev"]
+script:
+  - make lint
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,18 @@ branches:
   only:
   - master
   - develop
+before_install:
+  - sudo apt-get install swig
 install:
   - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
   - pip install -q -e .["dev"]
 script:
   - make lint
   - make test
+
+
+
+      before_install:
+        - export AUDIODEV=null
+        - cd ${TRAVIS_BUILD_DIR}
+        - sudo apt-get install swig

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,55 @@
 language: python
-python:
-  - "3.7"
-branches:
-  only:
-  - master
-  - develop
-install:
-  - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  - pip install -q -e .["dev"]
-script:
-  - make lint
-  - make test
+
+jobs:
+  - name "Python 3.6 on Linux"
+    python: 3.6
+    branches:
+      only:
+        - master
+        - develop
+    install:
+      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - pip install -q -e .["dev"]
+    script:
+      - make lint
+      - make test
+
+  - name "Python 3.7 on Linux"
+    python: 3.7
+    branches:
+      only:
+        - master
+        - develop
+    install:
+      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - pip install -q -e .["dev"]
+    script:
+      - make lint
+      - make test
+
+  - name "Python 3.8 on Linux"
+    python: 3.8
+    branches:
+      only:
+        - master
+        - develop
+    install:
+      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - pip install -q -e .["dev"]
+    script:
+      - make lint
+      - make test
+
+  - name "Python 3.9 on Linux"
+    python: 3.9
+    branches:
+      only:
+        - master
+        - develop
+    install:
+      - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - pip install -q -e .["dev"]
+    script:
+      - make lint
+      - make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,3 @@ install:
 script:
   - make lint
   - make test
-
-
-
-      before_install:
-        - export AUDIODEV=null
-        - cd ${TRAVIS_BUILD_DIR}
-        - sudo apt-get install swig


### PR DESCRIPTION
Adds 3.6-3.8 to CI. Testing this locally is hard, so when this inevitably fails I'll add fixes. Travis doesn't support 3.8.