### PR TITLE
Hotfix/logdir

### DIFF
--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -12,11 +12,12 @@ class ParallelEnvExperiment(Experiment):
             self,
             agent,
             env,
-            render=False,
+            logdir='runs',
             quiet=False,
+            render=False,
             write_loss=True
     ):
-        super().__init__(self._make_writer(agent[0].__name__, env.name, write_loss), quiet)
+        super().__init__(self._make_writer(logdir, agent[0].__name__, env.name, write_loss), quiet)
         make_agent, n_envs = agent
         self._envs = env.duplicate(n_envs)
         self._agent = make_agent(self._envs, self._writer)
@@ -145,5 +146,5 @@ class ParallelEnvExperiment(Experiment):
         end_time = timer()
         return (self._frame - self._episode_start_frames[i]) / (end_time - self._episode_start_times[i])
 
-    def _make_writer(self, agent_name, env_name, write_loss):
-        return ExperimentWriter(self, agent_name, env_name, loss=write_loss)
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
+        return ExperimentWriter(self, agent_name, env_name, loss=write_loss, logdir=logdir)

--- a/all/experiments/parallel_env_experiment_test.py
+++ b/all/experiments/parallel_env_experiment_test.py
@@ -8,7 +8,7 @@ from all.experiments.single_env_experiment_test import MockWriter
 
 # pylint: disable=protected-access
 class MockExperiment(ParallelEnvExperiment):
-    def _make_writer(self, agent_name, env_name, write_loss):
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
         self._writer = MockWriter(self, agent_name + '_' +  env_name, write_loss)
         return self._writer
 

--- a/all/experiments/run_experiment.py
+++ b/all/experiments/run_experiment.py
@@ -6,10 +6,11 @@ def run_experiment(
         agents,
         envs,
         frames,
-        test_episodes=100,
-        render=False,
+        logdir='runs',
         quiet=False,
-        write_loss=True,
+        render=False,
+        test_episodes=100,
+        write_loss=True
 ):
     if not isinstance(agents, list):
         agents = [agents]
@@ -23,8 +24,9 @@ def run_experiment(
             experiment = make_experiment(
                 agent,
                 env,
-                render=render,
+                logdir=logdir,
                 quiet=quiet,
+                render=render,
                 write_loss=write_loss
             )
             experiment.train(frames=frames)

--- a/all/experiments/single_env_experiment.py
+++ b/all/experiments/single_env_experiment.py
@@ -9,11 +9,12 @@ class SingleEnvExperiment(Experiment):
             self,
             agent,
             env,
-            render=False,
+            logdir='runs',
             quiet=False,
+            render=False,
             write_loss=True
     ):
-        super().__init__(self._make_writer(agent.__name__, env.name, write_loss), quiet)
+        super().__init__(self._make_writer(logdir, agent.__name__, env.name, write_loss), quiet)
         self._agent = agent(env, self._writer)
         self._env = env
         self._render = render
@@ -92,5 +93,5 @@ class SingleEnvExperiment(Experiment):
     def _done(self, frames, episodes):
         return self._frame > frames or self._episode > episodes
 
-    def _make_writer(self, agent_name, env_name, write_loss):
-        return ExperimentWriter(self, agent_name, env_name, loss=write_loss)
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
+        return ExperimentWriter(self, agent_name, env_name, loss=write_loss, logdir=logdir)

--- a/all/experiments/single_env_experiment_test.py
+++ b/all/experiments/single_env_experiment_test.py
@@ -43,7 +43,7 @@ class MockWriter(Writer):
 
 
 class MockExperiment(SingleEnvExperiment):
-    def _make_writer(self, agent_name, env_name, write_loss):
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
         self._writer = MockWriter(self, agent_name + '_' +  env_name, write_loss)
         return self._writer
 

--- a/all/experiments/writer.py
+++ b/all/experiments/writer.py
@@ -10,7 +10,7 @@ from all.logging import Writer
 class ExperimentWriter(SummaryWriter, Writer):
     '''
     The Writer object used by all.experiments.Experiment.
-    Writes logs using tensorboard into the current `runs` directory,
+    Writes logs using tensorboard into the current logdir directory ('runs' by default),
     tagging the run with a combination of the agent name, the commit hash of the
     current git repo of the working directory (if any), and the current time.
     Also writes summary statistics into CSV files.
@@ -20,16 +20,16 @@ class ExperimentWriter(SummaryWriter, Writer):
         env_name (str): The name of the environment the Experiment is being performed in
         loss (bool, optional): Whether or not to log loss/scheduling metrics, or only evaluation and summary metrics.
     '''
-    def __init__(self, experiment, agent_name, env_name, loss=True):
+    def __init__(self, experiment, agent_name, env_name, loss=True, logdir='runs'):
         self.env_name = env_name
         current_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S %f')
         os.makedirs(
             os.path.join(
-                "runs", ("%s %s %s" % (agent_name, COMMIT_HASH, current_time)), env_name
+                logdir, ("%s %s %s" % (agent_name, COMMIT_HASH, current_time)), env_name
             )
         )
         self.log_dir = os.path.join(
-            "runs", ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
+            logdir, ("%s %s %s" % (agent_name, COMMIT_HASH, current_time))
         )
         self._experiment = experiment
         self._loss = loss
@@ -81,8 +81,3 @@ def get_commit_hash():
 
 
 COMMIT_HASH = get_commit_hash()
-
-try:
-    os.mkdir("runs")
-except FileExistsError:
-    pass

--- a/all/policies/deterministic_test.py
+++ b/all/policies/deterministic_test.py
@@ -4,7 +4,7 @@ import torch_testing as tt
 import numpy as np
 from gym.spaces import Box
 from all import nn
-from all.approximation import FixedTarget
+from all.approximation import FixedTarget, DummyCheckpointer
 from all.core import State
 from all.policies import DeterministicPolicy
 
@@ -22,7 +22,8 @@ class TestDeterministic(unittest.TestCase):
         self.policy = DeterministicPolicy(
             self.model,
             self.optimizer,
-            self.space
+            self.space,
+            checkpointer=DummyCheckpointer()
         )
 
     def test_output_shape(self):

--- a/all/policies/gaussian_test.py
+++ b/all/policies/gaussian_test.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 import torch_testing as tt
 from gym.spaces import Box
+from all.approximation import DummyCheckpointer
 from all.core import State
 from all.policies import GaussianPolicy
 
@@ -12,14 +13,13 @@ ACTION_DIM = 3
 
 class TestGaussian(unittest.TestCase):
     def setUp(self):
-
         torch.manual_seed(2)
         self.space = Box(np.array([-1, -1, -1]), np.array([1, 1, 1]))
         self.model = nn.Sequential(
             nn.Linear(STATE_DIM, ACTION_DIM * 2)
         )
         optimizer = torch.optim.RMSprop(self.model.parameters(), lr=0.01)
-        self.policy = GaussianPolicy(self.model, optimizer, self.space)
+        self.policy = GaussianPolicy(self.model, optimizer, self.space, checkpointer=DummyCheckpointer())
 
     def test_output_shape(self):
         state = State(torch.randn(1, STATE_DIM))

--- a/all/policies/soft_deterministic_test.py
+++ b/all/policies/soft_deterministic_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import torch_testing as tt
 from gym.spaces import Box
 from all import nn
+from all.approximation import DummyCheckpointer
 from all.core import State
 from all.policies import SoftDeterministicPolicy
 
@@ -21,7 +22,8 @@ class TestSoftDeterministic(unittest.TestCase):
         self.policy = SoftDeterministicPolicy(
             self.model,
             self.optimizer,
-            self.space
+            self.space,
+            checkpointer=DummyCheckpointer()
         )
 
     def test_output_shape(self):

--- a/all/presets/validate_agent.py
+++ b/all/presets/validate_agent.py
@@ -1,12 +1,15 @@
+import os
 from all.logging import DummyWriter
 from all.experiments import SingleEnvExperiment, ParallelEnvExperiment
 
 class TestSingleEnvExperiment(SingleEnvExperiment):
-    def _make_writer(self, agent_name, env_name, write_loss):
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
+        os.makedirs(logdir, exist_ok=True)
         return DummyWriter()
 
 class TestParallelEnvExperiment(ParallelEnvExperiment):
-    def _make_writer(self, agent_name, env_name, write_loss):
+    def _make_writer(self, logdir, agent_name, env_name, write_loss):
+        os.makedirs(logdir, exist_ok=True)
         return DummyWriter()
 
 def validate_agent(agent, env):

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -20,13 +20,22 @@ def main():
     parser.add_argument(
         "--render", type=bool, default=False, help="Render the environment."
     )
+    parser.add_argument(
+        "--logdir", default='runs', help="The base logging directory."
+    )
     args = parser.parse_args()
 
     env = AtariEnvironment(args.env, device=args.device)
     agent_name = args.agent
     agent = getattr(atari, agent_name)
 
-    run_experiment(agent(device=args.device, last_frame=args.frames), env, args.frames, render=args.render)
+    run_experiment(
+        agent(device=args.device, last_frame=args.frames),
+        env,
+        args.frames,
+        render=args.render,
+        logdir=args.logdir
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/classic.py
+++ b/scripts/classic.py
@@ -21,13 +21,16 @@ def main():
     parser.add_argument(
         "--render", type=bool, default=False, help="Render the environment."
     )
+    parser.add_argument(
+        "--logdir", default='runs', help="The base logging directory."
+    )
     args = parser.parse_args()
 
     env = GymEnvironment(args.env, device=args.device)
     agent_name = args.agent
     agent = getattr(classic_control, agent_name)
 
-    run_experiment(agent(device=args.device), env, args.frames, render=args.render)
+    run_experiment(agent(device=args.device), env, args.frames, render=args.render, logdir=args.logdir)
 
 
 if __name__ == "__main__":

--- a/scripts/continuous.py
+++ b/scripts/continuous.py
@@ -38,6 +38,9 @@ def main():
     parser.add_argument(
         "--render", type=bool, default=False, help="Render the environment."
     )
+    parser.add_argument(
+        "--logdir", default='runs', help="The base logging directory."
+    )
     args = parser.parse_args()
 
     if args.env in ENVS:
@@ -49,7 +52,7 @@ def main():
     agent_name = args.agent
     agent = getattr(continuous, agent_name)
 
-    run_experiment(agent(device=args.device), env, frames=args.frames, render=args.render)
+    run_experiment(agent(device=args.device), env, frames=args.frames, render=args.render, logdir=args.logdir)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "gym[atari,box2d]",     # common environments
         "numpy",                # math library
         "matplotlib",           # plotting library
-        "opencv-python",        # used by atari wrappers
+        "opencv-python>=3.,<4.",# used by atari wrappers
         "pybullet",             # continuous environments
         "tensorboardX",         # tensorboard compatibility
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autonomous-learning-library",
-    version="0.6.1",
+    version="0.6.2",
     description=("A library for building reinforcement learning agents in Pytorch"),
     packages=find_packages(),
     url="https://github.com/cpnota/autonomous-learning-library.git",


### PR DESCRIPTION
Sneaking in a quick enhancement before some larger changes. Addressing #174 .

`run_experiment` now accepts an optional `logdir` parameter. Additionally, a `logdir` parameter was added to the run scripts, allowing the following usage:

```python
all-atari Breakout dqn --logdir my/cool/dir
```