### PR TITLE
Alternate Setup Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install swig
 install:
   - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  - pip install -q -e .["dev"]
+  - pip install -e .["all"]
 script:
   - make lint
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install swig
 install:
   - pip install torch==1.5.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  - pip install -e .["dev"]
+  - pip install -e .["dev"] --use-feature=2020-resolver
 script:
   - make lint
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ branches:
 before_install:
   - sudo apt-get install swig
 install:
-  - pip install torch==1.5.1+cpu torchvision==0.6.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  - pip install -e .["all"]
+  - pip install torch==1.5.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+  - pip install -e .["dev"]
 script:
   - make lint
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install swig
 install:
   - pip install torch==1.5.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  - pip install -e .["dev"] --use-feature=2020-resolver
+  - pip install -e .["dev"]
 script:
   - make lint
   - make test

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,11 @@ extras = {
     "dev": [
         "pylint>=2.6.0",             # code quality tool
         "torch-testing>=0.0.2",      # pytorch assertion library
+    ],
+    "envs": [
         "gym[atari,box2d]>=0.17.2",  # common environments
         "pybullet>=3.0.6"            # continuous environments
-    ]
+        ]
     }
 
 extras["all"] = list(set().union(extras["docs"], extras["dev"]))

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers
         "torch>=1.5.1",            # deep learning
-        "torchvision>=0.6.1"       # additional utilities
+        "torchvision>=0.6.1",      # additional utilities
+        "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.3.0",     # tensorboard/pytorch compatibility
     ],
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,15 @@ from setuptools import setup, find_packages
 
 
 extras = {
-    "envs": [
+    "atari": [
         "atari_py~=0.2.0",            # atari environments
-        "box2d-py~=2.3.5",            # box2d environments
-        "pybullet>=3.0.6",            # continuous environments
         "Pillow",                     # rendering library
+    ],
+    "box2d": [
+        "box2d-py~=2.3.5",
+    ],
+    "pybullet": [
+        "pybullet>=3.0.6",            # continuous environments
     ],
     "test": [
         "pylint>=2.6.0",              # code quality tool
@@ -20,8 +24,8 @@ extras = {
     ]
 }
 
-extras["dev"] = extras["envs"] + extras["test"] + extras["docs"]
-
+extras["all"] = extras["atari"]  + extras["box2d"] + extras["pybullet"]
+extras["dev"] = extras["all"] + extras["test"] + extras["docs"]
 
 setup(
     name="autonomous-learning-library",
@@ -49,7 +53,7 @@ setup(
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1,<1.6",       # core deep learning library
+        "torch>=1.5.1",       # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,6 @@
 from setuptools import setup, find_packages
 
 
-extras = {
-    "envs": [
-        "gym[atari,box2d]>=0.17.2",  # common environments
-        "pybullet>=3.0.6"            # continuous environments
-    ],
-    "test": [
-        "pylint>=2.6.0",             # code quality tool
-        "torch-testing>=0.0.2",      # pytorch assertion library
-    ],
-    "docs": [
-        "sphinx>=3.2.1",
-        "sphinx-autobuild>=2020.9.1",
-        "sphinx-rtd-theme>=0.5.0",
-        "sphinx-automodapi>=0.13",
-    ],
-}
-
-
-def union(*deps):
-    return list(set().union(*[extras[dep] for dep in deps]))
-
-extras["dev"] = union("envs", "docs", "test")
-
 setup(
     name="autonomous-learning-library",
     version="0.6.2",
@@ -46,18 +23,26 @@ setup(
         ],
     },
     install_requires=[
-        "gym>=0.17.2",             # common environment interface
-        "numpy>=1.18.0",           # math library
-        "matplotlib>=3.3.0",       # plotting library
-        "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1",            # core deep learning library
-        "tensorboard>=2.3.0",      # logging and visualization
-        "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
+        "gym>=0.17.2",                    # common environment interface
+        "numpy>=1.18.0",                  # math library
+        "matplotlib>=3.3.0",              # plotting library
+        "opencv-python>=3.,<4.",          # used by atari wrappers
+        "torch>=1.5.1",                   # core deep learning library
+        "tensorboard>=2.3.0",             # logging and visualization
+        "tensorboardX>=2.1.0",            # tensorboard/pytorch compatibility
     ],
     extras_require={
         "envs": [
-            "gym[atari,box2d]>=0.17.2",  # common environments
-            "pybullet>=3.0.6"            # continuous environments
+            "gym[atari,box2d]>=0.17.2",   # common environments
+            "pybullet>=3.0.6",            # continuous environments
         ],
+        "dev": [
+            "pylint>=2.6.0",              # code quality tool
+            "torch-testing>=0.0.2",       # pytorch assertion library
+            "sphinx>=3.2.1",              # documentation library
+            "sphinx-autobuild>=2020.9.1", # documentation live reload
+            "sphinx-rtd-theme>=0.5.0",    # documentation theme
+            "sphinx-automodapi>=0.13",    # autogenerate docs for modules
+        ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
     ]
 }
 
-extras["all"] = list(set().union(extras["docs"], extras["dev"]))
+extras["all"] = list(set().union(*extras.values()))
 
 setup(
     name="autonomous-learning-library",

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,28 @@
 from setuptools import setup, find_packages
 
+
 extras = {
+    "envs": [
+        "gym[atari,box2d]>=0.17.2",  # common environments
+        "pybullet>=3.0.6"            # continuous environments
+    ],
+    "test": [
+        "pylint>=2.6.0",             # code quality tool
+        "torch-testing>=0.0.2",      # pytorch assertion library
+    ],
     "docs": [
         "sphinx>=3.2.1",
         "sphinx-autobuild>=2020.9.1",
         "sphinx-rtd-theme>=0.5.0",
-        "sphinx-automodapi>=0.13"
+        "sphinx-automodapi>=0.13",
     ],
-    "dev": [
-        "pylint>=2.6.0",             # code quality tool
-        "torch-testing>=0.0.2",      # pytorch assertion library
-    ],
-    "envs": [
-        "gym[atari,box2d]>=0.17.2",  # common environments
-        "pybullet>=3.0.6"            # continuous environments
-    ]
 }
 
-extras["all"] = list(set().union(*extras.values()))
+
+def union(*deps):
+    return list(set().union(*[extras[dep] for dep in deps]))
+
+extras["dev"] = union("envs", "docs", "test")
 
 setup(
     name="autonomous-learning-library",
@@ -45,10 +50,14 @@ setup(
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1",            # deep learning
-        "torchvision>=0.6.1",      # additional utilities
+        "torch>=1.5.1",            # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
-        "tensorboardX>=2.3.0",     # tensorboard/pytorch compatibility
+        "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],
-    extras_require=extras,
+    extras_require={
+        "envs": [
+            "gym[atari,box2d]>=0.17.2",  # common environments
+            "pybullet>=3.0.6"            # continuous environments
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,13 @@ extras = {
     ],
     "dev": [
         "pylint>=2.6.0",             # code quality tool
-        "torch-testing?=0.0.2",      # pytorch assertion library
-        "gym[atari,box2d>=0.17.2]",  # common environments
+        "torch-testing>=0.0.2",      # pytorch assertion library
+        "gym[atari,box2d]>=0.17.2",  # common environments
         "pybullet>=3.0.6"            # continuous environments
     ]
     }
 
 extras["all"] = list(set().union(extras["docs"], extras["dev"]))
-
 
 setup(
     name="autonomous-learning-library",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,23 @@
 from setuptools import setup, find_packages
 
+extras = {
+    "docs": [
+        "sphinx>=3.2.1",
+        "sphinx-autobuild>=2020.9.1",
+        "sphinx-rtd-theme>=0.5.0",
+        "sphinx-automodapi>=0.13"
+    ],
+    "dev": [
+        "pylint>=2.6.0",             # code quality tool
+        "torch-testing?=0.0.2",      # pytorch assertion library
+        "gym[atari,box2d>=0.17.2]",  # common environments
+        "pybullet>=3.0.6"            # continuous environments
+    ]
+    }
+
+extras["all"] = list(set().union(extras["docs"], extras["dev"]))
+
+
 setup(
     name="autonomous-learning-library",
     version="0.6.1",
@@ -22,28 +40,12 @@ setup(
         ],
     },
     install_requires=[
-        "gym[atari,box2d]",     # common environments
-        "numpy",                # math library
-        "matplotlib",           # plotting library
-        "opencv-python",        # used by atari wrappers
-        "pybullet",             # continuous environments
-        "tensorboardX",         # tensorboard compatibility
+        "gym>=0.17.2",             # common environments
+        "numpy>=1.18.0",           # math library
+        "matplotlib>=3.3.0",       # plotting library
+        "opencv-python>4.4.0.42",  # used by atari wrappers
+        "torch==1.5.1",            # deep learning
+        "torchvision==0.6.1"       # additional utilities
     ],
-    extras_require={
-        "pytorch": [
-            "torch",            # deep learning
-            "torchvision",      # additional utilities
-            "tensorboard"       # visualizations
-        ],
-        "docs": [
-            "sphinx",
-            "sphinx-autobuild",
-            "sphinx-rtd-theme",
-            "sphinx-automodapi"
-        ],
-        "dev": [
-            "pylint",           # code quality tool
-            "torch-testing"     # pytorch assertion library
-        ]
-    },
+    extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         ],
     },
     install_requires=[
-        "gym>=0.17.2",             # common environments
+        "gym>=0.17.2",             # common environment interface
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 from setuptools import setup, find_packages
 
 
-def union(*deps):
-    return list(set().union(*[extras[dep] for dep in deps]))
-
 extras = {
     "envs": [
         "atari_py~=0.2.0",            # atari environments
@@ -23,7 +20,7 @@ extras = {
     ]
 }
 
-extras["dev"] = union("envs", "test", "docs")
+extras["dev"] = extras["envs"] + extras["test"] + extras["docs"]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1",            # core deep learning library
+        "torch>=1.5.1,<1.7",       # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "opencv-python>4.4.0.42",  # used by atari wrappers
         "torch>=1.5.1",            # deep learning
         "torchvision>=0.6.1"       # additional utilities
+        "tensorboardX>=2.3.0",     # tensorboard compatibility
     ],
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ from setuptools import setup, find_packages
 extras = {
     "atari": [
         "atari_py~=0.2.0",            # atari environments
-        "Pillow",                     # rendering library
+        "Pillow~=7.1.2",              # rendering library
     ],
     "box2d": [
-        "box2d-py~=2.3.5",
+        "box2d-py~=2.3.5",            # box3d physics environments
     ],
     "pybullet": [
-        "pybullet>=3.0.6",            # continuous environments
+        "pybullet>=3.0.6",            # open-source robotics environments
     ],
     "test": [
         "pylint>=2.6.0",              # code quality tool
@@ -49,11 +49,11 @@ setup(
         ],
     },
     install_requires=[
-        "gym>=0.17.2",             # common environment interface
+        "gym~=0.17.2",             # common environment interface
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
-        "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1",       # core deep learning library
+        "opencv-python~=3.4",      # used by atari wrappers
+        "torch~=1.5.1",            # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ extras = {
     "envs": [
         "gym[atari,box2d]>=0.17.2",  # common environments
         "pybullet>=3.0.6"            # continuous environments
-        ]
-    }
+    ]
+}
 
 extras["all"] = list(set().union(extras["docs"], extras["dev"]))
 

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,14 @@ def union(*deps):
 
 extras = {
     "envs": [
-        "gym[atari,box2d]>=0.17.2",  # common environments
-        "pybullet>=3.0.6",           # continuous environments
+        "atari_py~=0.2.0",            # atari environments
+        "box2d-py~=2.3.5",            # box2d environments
+        "pybullet>=3.0.6",            # continuous environments
+        "Pillow",                     # rendering library
     ],
     "test": [
-        "pylint>=2.6.0",             # code quality tool
-        "torch-testing>=0.0.2",      # pytorch assertion library
+        "pylint>=2.6.0",              # code quality tool
+        "torch-testing>=0.0.2",       # pytorch assertion library
     ],
     "docs": [
         "sphinx>=3.2.1",              # documentation library
@@ -50,7 +52,7 @@ setup(
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>=3.,<4.",   # used by atari wrappers
-        "torch>=1.5.1,<1.7",       # core deep learning library
+        "torch>=1.5.1,<1.6",       # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,29 @@
 from setuptools import setup, find_packages
 
 
+def union(*deps):
+    return list(set().union(*[extras[dep] for dep in deps]))
+
+extras = {
+    "envs": [
+        "gym[atari,box2d]>=0.17.2",  # common environments
+        "pybullet>=3.0.6",           # continuous environments
+    ],
+    "test": [
+        "pylint>=2.6.0",             # code quality tool
+        "torch-testing>=0.0.2",      # pytorch assertion library
+    ],
+    "docs": [
+        "sphinx>=3.2.1",              # documentation library
+        "sphinx-autobuild>=2020.9.1", # documentation live reload
+        "sphinx-rtd-theme>=0.5.0",    # documentation theme
+        "sphinx-automodapi>=0.13",    # autogenerate docs for modules
+    ]
+}
+
+extras["dev"] = union("envs", "test", "docs")
+
+
 setup(
     name="autonomous-learning-library",
     version="0.6.2",
@@ -23,26 +46,13 @@ setup(
         ],
     },
     install_requires=[
-        "gym>=0.17.2",                    # common environment interface
-        "numpy>=1.18.0",                  # math library
-        "matplotlib>=3.3.0",              # plotting library
-        "opencv-python>=3.,<4.",          # used by atari wrappers
-        "torch>=1.5.1",                   # core deep learning library
-        "tensorboard>=2.3.0",             # logging and visualization
-        "tensorboardX>=2.1.0",            # tensorboard/pytorch compatibility
+        "gym>=0.17.2",             # common environment interface
+        "numpy>=1.18.0",           # math library
+        "matplotlib>=3.3.0",       # plotting library
+        "opencv-python>=3.,<4.",   # used by atari wrappers
+        "torch>=1.5.1",            # core deep learning library
+        "tensorboard>=2.3.0",      # logging and visualization
+        "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
     ],
-    extras_require={
-        "envs": [
-            "gym[atari,box2d]>=0.17.2",   # common environments
-            "pybullet>=3.0.6",            # continuous environments
-        ],
-        "dev": [
-            "pylint>=2.6.0",              # code quality tool
-            "torch-testing>=0.0.2",       # pytorch assertion library
-            "sphinx>=3.2.1",              # documentation library
-            "sphinx-autobuild>=2020.9.1", # documentation live reload
-            "sphinx-rtd-theme>=0.5.0",    # documentation theme
-            "sphinx-automodapi>=0.13",    # autogenerate docs for modules
-        ]
-    },
+    extras_require=extras
 )

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
         "numpy>=1.18.0",           # math library
         "matplotlib>=3.3.0",       # plotting library
         "opencv-python>4.4.0.42",  # used by atari wrappers
-        "torch==1.5.1",            # deep learning
-        "torchvision==0.6.1"       # additional utilities
+        "torch>=1.5.1",            # deep learning
+        "torchvision>=0.6.1"       # additional utilities
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
Latest proposal after discussing with @andrewsmike . This offers three basic installations:

```bash
pip install autonomous-learning-library          # just the core stuff
pip install autonomous-learning-library["envs"]  # core + atari, box2d, and pybullet
pip install autonomous-learning-library["dev"]   # core + envs + testing + docs
```

I think "dev" makes captures the use case better than "all" and is more standard. @andrewsmike also recommended adding several `requirements-{envs|dev|ci}.txt` files for different use cases. This can be used, for instance, to ensure that the cpu version of torch is installed on the continuous integration server (right now it will fail).

Edit:

After some thought, the environments were split up to match gym:"

```bash
pip install autonomous-learning-library              # just the core stuff
pip install autonomous-learning-library["atari"]     # atari environments
pip install autonomous-learning-library["pybullet"]  # robotics environments
pip install autonomous-learning-library["box2d"]     # box2d environments
pip install autonomous-learning-library["all"]       # all environments
pip install autonomous-learning-library["dev"]       # core + envs + testing + docs
```

The reasoning is that as more environments/presets are added, it may be increasingly important to only install a desired subset, especially given the (in my experience) frequent issues with installing environments