### PR TITLE
Feature/save agents

### DIFF
--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -3,7 +3,7 @@ from .a2c import A2C
 from .c51 import C51
 from .ddpg import DDPG
 from .ddqn import DDQN
-from .dqn import DQN
+from .dqn import DQN, DQNTestAgent
 from .ppo import PPO
 from .rainbow import Rainbow
 from .sac import SAC
@@ -19,6 +19,7 @@ __all__ = [
     "DDPG",
     "DDQN",
     "DQN",
+    "DQNTestAgent",
     "PPO",
     "Rainbow",
     "SAC",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -5,7 +5,7 @@ from .ddpg import DDPG
 from .ddqn import DDQN, DDQNTestAgent
 from .dqn import DQN, DQNTestAgent
 from .ppo import PPO, PPOTestAgent
-from .rainbow import Rainbow
+from .rainbow import Rainbow, RainbowTestAgent
 from .sac import SAC
 from .vac import VAC
 from .vpg import VPG
@@ -26,6 +26,7 @@ __all__ = [
     "PPO",
     "PPOTestAgent",
     "Rainbow",
+    "RainbowTestAgent",
     "SAC",
     "VAC",
     "VPG",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -7,7 +7,7 @@ from .dqn import DQN, DQNTestAgent
 from .ppo import PPO, PPOTestAgent
 from .rainbow import Rainbow, RainbowTestAgent
 from .sac import SAC
-from .vac import VAC
+from .vac import VAC, VACTestAgent
 from .vpg import VPG
 from .vqn import VQN
 from .vsarsa import VSarsa
@@ -29,6 +29,7 @@ __all__ = [
     "RainbowTestAgent",
     "SAC",
     "VAC",
+    "VACTestAgent",
     "VPG",
     "VQN",
     "VSarsa",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -15,7 +15,7 @@ from .vsarsa import VSarsa, VSarsaTestAgent
 __all__ = [
     "Agent",
     "A2C",
-    "A2CTestAgent"
+    "A2CTestAgent",
     "C51",
     "C51TestAgent",
     "DDPG",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -4,7 +4,7 @@ from .c51 import C51, C51TestAgent
 from .ddpg import DDPG
 from .ddqn import DDQN, DDQNTestAgent
 from .dqn import DQN, DQNTestAgent
-from .ppo import PPO
+from .ppo import PPO, PPOTestAgent
 from .rainbow import Rainbow
 from .sac import SAC
 from .vac import VAC
@@ -24,6 +24,7 @@ __all__ = [
     "DQN",
     "DQNTestAgent",
     "PPO",
+    "PPOTestAgent",
     "Rainbow",
     "SAC",
     "VAC",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -1,5 +1,5 @@
 from ._agent import Agent
-from .a2c import A2C
+from .a2c import A2C, A2CTestAgent
 from .c51 import C51
 from .ddpg import DDPG
 from .ddqn import DDQN
@@ -15,6 +15,7 @@ from .vsarsa import VSarsa
 __all__ = [
     "Agent",
     "A2C",
+    "A2CTestAgent"
     "C51",
     "DDPG",
     "DDQN",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -9,8 +9,8 @@ from .rainbow import Rainbow, RainbowTestAgent
 from .sac import SAC
 from .vac import VAC, VACTestAgent
 from .vpg import VPG, VPGTestAgent
-from .vqn import VQN
-from .vsarsa import VSarsa
+from .vqn import VQN, VQNTestAgent
+from .vsarsa import VSarsa, VSarsaTestAgent
 
 __all__ = [
     "Agent",
@@ -33,5 +33,7 @@ __all__ = [
     "VPG",
     "VPGTestAgent",
     "VQN",
+    "VQNTestAgent",
     "VSarsa",
+    "VSarsaTestAgent"
 ]

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -8,7 +8,7 @@ from .ppo import PPO, PPOTestAgent
 from .rainbow import Rainbow, RainbowTestAgent
 from .sac import SAC
 from .vac import VAC, VACTestAgent
-from .vpg import VPG
+from .vpg import VPG, VPGTestAgent
 from .vqn import VQN
 from .vsarsa import VSarsa
 
@@ -31,6 +31,7 @@ __all__ = [
     "VAC",
     "VACTestAgent",
     "VPG",
+    "VPGTestAgent",
     "VQN",
     "VSarsa",
 ]

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -2,7 +2,7 @@ from ._agent import Agent
 from .a2c import A2C, A2CTestAgent
 from .c51 import C51, C51TestAgent
 from .ddpg import DDPG
-from .ddqn import DDQN
+from .ddqn import DDQN, DDQNTestAgent
 from .dqn import DQN, DQNTestAgent
 from .ppo import PPO
 from .rainbow import Rainbow
@@ -20,6 +20,7 @@ __all__ = [
     "C51TestAgent",
     "DDPG",
     "DDQN",
+    "DDQNTestAgent",
     "DQN",
     "DQNTestAgent",
     "PPO",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -1,6 +1,6 @@
 from ._agent import Agent
 from .a2c import A2C, A2CTestAgent
-from .c51 import C51
+from .c51 import C51, C51TestAgent
 from .ddpg import DDPG
 from .ddqn import DDQN
 from .dqn import DQN, DQNTestAgent
@@ -17,6 +17,7 @@ __all__ = [
     "A2C",
     "A2CTestAgent"
     "C51",
+    "C51TestAgent",
     "DDPG",
     "DDQN",
     "DQN",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -1,7 +1,7 @@
 from ._agent import Agent
 from .a2c import A2C, A2CTestAgent
 from .c51 import C51, C51TestAgent
-from .ddpg import DDPG
+from .ddpg import DDPG, DDPGTestAgent
 from .ddqn import DDQN, DDQNTestAgent
 from .dqn import DQN, DQNTestAgent
 from .ppo import PPO, PPOTestAgent
@@ -19,6 +19,7 @@ __all__ = [
     "C51",
     "C51TestAgent",
     "DDPG",
+    "DDPGTestAgent",
     "DDQN",
     "DDQNTestAgent",
     "DQN",

--- a/all/agents/__init__.py
+++ b/all/agents/__init__.py
@@ -6,7 +6,7 @@ from .ddqn import DDQN, DDQNTestAgent
 from .dqn import DQN, DQNTestAgent
 from .ppo import PPO, PPOTestAgent
 from .rainbow import Rainbow, RainbowTestAgent
-from .sac import SAC
+from .sac import SAC, SACTestAgent
 from .vac import VAC, VACTestAgent
 from .vpg import VPG, VPGTestAgent
 from .vqn import VQN, VQNTestAgent
@@ -29,6 +29,7 @@ __all__ = [
     "Rainbow",
     "RainbowTestAgent",
     "SAC",
+    "SACTestAgent",
     "VAC",
     "VACTestAgent",
     "VPG",

--- a/all/agents/_agent.py
+++ b/all/agents/_agent.py
@@ -32,20 +32,3 @@ class Agent(ABC, Schedulable):
         Returns:
             torch.Tensor: The action to take at the current timestep.
         """
-
-    @abstractmethod
-    def eval(self, state):
-        """
-        Select an action for the current timestep in evaluation mode.
-
-        Unlike act, this method should NOT update the internal parameters of the agent.
-        Most of the time, this method should return the greedy action according to the current policy.
-        This method is useful when using evaluation methodologies that distinguish between the performance
-        of the agent during training and the performance of the resulting policy.
-
-        Args:
-            state (all.environment.State): The environment state at the current timestep.
-
-        Returns:
-            torch.Tensor: The action to take at the current timestep.
-        """

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -99,6 +99,7 @@ class A2C(Agent):
             discount_factor=self.discount_factor
         )
 
+
 class A2CTestAgent(Agent):
     def __init__(self, features, policy):
         self.features = features

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -1,3 +1,4 @@
+import torch
 from torch.nn.functional import mse_loss
 from all.logging import DummyWriter
 from all.memory import NStepAdvantageBuffer
@@ -61,9 +62,6 @@ class A2C(Agent):
         self._actions = self.policy.no_grad(self.features.no_grad(states)).sample()
         return self._actions
 
-    def eval(self, states):
-        return self.policy.eval(self.features.eval(states))
-
     def _train(self, next_states):
         if len(self._buffer) >= self._batch_size:
             # load trajectories from buffer
@@ -100,3 +98,12 @@ class A2C(Agent):
             self.n_envs,
             discount_factor=self.discount_factor
         )
+
+class A2CTestAgent(Agent):
+    def __init__(self, feature_model, policy_model):
+        self.feature_model = feature_model
+        self.policy_model = policy_model
+
+    def act(self, state):
+        probs = self.policy_model(self.feature_model(state.as_input('observation')))
+        return torch.argmax(probs, dim=-1)

--- a/all/agents/a2c.py
+++ b/all/agents/a2c.py
@@ -100,10 +100,9 @@ class A2C(Agent):
         )
 
 class A2CTestAgent(Agent):
-    def __init__(self, feature_model, policy_model):
-        self.feature_model = feature_model
-        self.policy_model = policy_model
+    def __init__(self, features, policy):
+        self.features = features
+        self.policy = policy
 
     def act(self, state):
-        probs = self.policy_model(self.feature_model(state.as_input('observation')))
-        return torch.argmax(probs, dim=-1)
+        return self.policy.eval(self.features.eval(state)).sample()

--- a/all/agents/c51.py
+++ b/all/agents/c51.py
@@ -114,3 +114,15 @@ class C51(Agent):
         log_dist = torch.log(torch.clamp(dist, min=self.eps))
         log_target_dist = torch.log(torch.clamp(target_dist, min=self.eps))
         return (target_dist * (log_target_dist - log_dist)).sum(dim=-1)
+
+class C51TestAgent(Agent):
+    def __init__(self, q_dist, n_actions, exploration=0.):
+        self.q_dist = q_dist
+        self.n_actions = n_actions
+        self.exploration = exploration
+
+    def act(self, state):
+        if np.random.rand() < self.exploration:
+            return np.random.randint(0, self.n_actions)
+        q_values = (self.q_dist(state) * self.q_dist.atoms).sum(dim=-1)
+        return torch.argmax(q_values, dim=-1)

--- a/all/agents/c51.py
+++ b/all/agents/c51.py
@@ -115,6 +115,7 @@ class C51(Agent):
         log_target_dist = torch.log(torch.clamp(target_dist, min=self.eps))
         return (target_dist * (log_target_dist - log_dist)).sum(dim=-1)
 
+
 class C51TestAgent(Agent):
     def __init__(self, q_dist, n_actions, exploration=0.):
         self.q_dist = q_dist

--- a/all/agents/ddpg.py
+++ b/all/agents/ddpg.py
@@ -93,3 +93,10 @@ class DDPG(Agent):
     def _should_train(self):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
+
+class DDPGTestAgent(Agent):
+    def __init__(self, policy):
+        self.policy = policy
+
+    def act(self, state):
+        return self.policy.eval(state)

--- a/all/agents/ddpg.py
+++ b/all/agents/ddpg.py
@@ -94,6 +94,7 @@ class DDPG(Agent):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
 
+
 class DDPGTestAgent(Agent):
     def __init__(self, policy):
         self.policy = policy

--- a/all/agents/ddqn.py
+++ b/all/agents/ddqn.py
@@ -1,6 +1,7 @@
 import torch
 from all.nn import weighted_mse_loss
 from ._agent import Agent
+from .dqn import DQNTestAgent
 
 
 class DDQN(Agent):
@@ -80,3 +81,5 @@ class DDQN(Agent):
     def _should_train(self):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
+
+DDQNTestAgent = DQNTestAgent

--- a/all/agents/ddqn.py
+++ b/all/agents/ddqn.py
@@ -82,4 +82,5 @@ class DDQN(Agent):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
 
+
 DDQNTestAgent = DQNTestAgent

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -79,7 +79,7 @@ class DQN(Agent):
         self._frames_seen += 1
         return (self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0)
 
-class DQNTestAgent():
+class DQNTestAgent(Agent):
     def __init__(self, model, n_actions, exploration=0.):
         self.model = model
         self.n_actions = n_actions
@@ -88,4 +88,5 @@ class DQNTestAgent():
     def act(self, state):
         if np.random.rand() < self.exploration:
             return np.random.randint(0, self.n_actions)
-        return torch.argmax(state.apply(self.model, 'observation')).item()
+        with torch.no_grad:
+            return torch.argmax(state.apply(self.model, 'observation')).item()

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 from torch.nn.functional import mse_loss
 from ._agent import Agent
@@ -77,3 +78,14 @@ class DQN(Agent):
     def _should_train(self):
         self._frames_seen += 1
         return (self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0)
+
+class DQNTestAgent():
+    def __init__(self, model, n_actions, exploration=0.):
+        self.model = model
+        self.n_actions = n_actions
+        self.exploration = exploration
+
+    def act(self, state):
+        if np.random.rand() < self.exploration:
+            return np.random.randint(0, self.n_actions)
+        return torch.argmax(state.apply(self.model, 'observation')).item()

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -80,13 +80,12 @@ class DQN(Agent):
         return (self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0)
 
 class DQNTestAgent(Agent):
-    def __init__(self, model, n_actions, exploration=0.):
-        self.model = model
+    def __init__(self, q, n_actions, exploration=0.):
+        self.q = q
         self.n_actions = n_actions
         self.exploration = exploration
 
     def act(self, state):
         if np.random.rand() < self.exploration:
             return np.random.randint(0, self.n_actions)
-        with torch.no_grad:
-            return torch.argmax(state.apply(self.model, 'observation')).item()
+        return torch.argmax(self.q.eval(state)).item()

--- a/all/agents/dqn.py
+++ b/all/agents/dqn.py
@@ -79,6 +79,7 @@ class DQN(Agent):
         self._frames_seen += 1
         return (self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0)
 
+
 class DQNTestAgent(Agent):
     def __init__(self, q, n_actions, exploration=0.):
         self.q = q

--- a/all/agents/ppo.py
+++ b/all/agents/ppo.py
@@ -141,4 +141,5 @@ class PPO(Agent):
             lam=self.lam
         )
 
+
 PPOTestAgent = A2CTestAgent

--- a/all/agents/ppo.py
+++ b/all/agents/ppo.py
@@ -3,6 +3,7 @@ from torch.nn.functional import mse_loss
 from all.logging import DummyWriter
 from all.memory import GeneralizedAdvantageBuffer
 from ._agent import Agent
+from .a2c import A2CTestAgent
 
 
 class PPO(Agent):
@@ -139,3 +140,5 @@ class PPO(Agent):
             discount_factor=self.discount_factor,
             lam=self.lam
         )
+
+PPOTestAgent = A2CTestAgent

--- a/all/agents/rainbow.py
+++ b/all/agents/rainbow.py
@@ -1,4 +1,4 @@
-from .c51 import C51
+from .c51 import C51, C51TestAgent
 
 
 class Rainbow(C51):
@@ -29,3 +29,5 @@ class Rainbow(C51):
             when training begins.
         update_frequency (int): Number of timesteps per training update.
     """
+
+RainbowTestAgent = C51TestAgent

--- a/all/agents/rainbow.py
+++ b/all/agents/rainbow.py
@@ -30,4 +30,5 @@ class Rainbow(C51):
         update_frequency (int): Number of timesteps per training update.
     """
 
+
 RainbowTestAgent = C51TestAgent

--- a/all/agents/sac.py
+++ b/all/agents/sac.py
@@ -72,9 +72,6 @@ class SAC(Agent):
         self._action = self.policy.no_grad(state)[0]
         return self._action
 
-    def eval(self, state):
-        return self.policy.eval(state)
-
     def _train(self):
         if self._should_train():
             # sample from replay buffer
@@ -113,3 +110,10 @@ class SAC(Agent):
     def _should_train(self):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
+
+class SACTestAgent(Agent):
+    def __init__(self, policy):
+        self.policy = policy
+
+    def act(self, state):
+        return self.policy.eval(state)

--- a/all/agents/sac.py
+++ b/all/agents/sac.py
@@ -111,6 +111,7 @@ class SAC(Agent):
         self._frames_seen += 1
         return self._frames_seen > self.replay_start_size and self._frames_seen % self.update_frequency == 0
 
+
 class SACTestAgent(Agent):
     def __init__(self, policy):
         self.policy = policy

--- a/all/agents/vac.py
+++ b/all/agents/vac.py
@@ -1,5 +1,6 @@
 from torch.nn.functional import mse_loss
 from ._agent import Agent
+from .a2c import A2CTestAgent
 
 
 class VAC(Agent):
@@ -56,3 +57,5 @@ class VAC(Agent):
             self.v.reinforce(value_loss)
             self.policy.reinforce(policy_loss)
             self.features.reinforce()
+
+VACTestAgent = A2CTestAgent

--- a/all/agents/vac.py
+++ b/all/agents/vac.py
@@ -58,4 +58,5 @@ class VAC(Agent):
             self.policy.reinforce(policy_loss)
             self.features.reinforce()
 
+
 VACTestAgent = A2CTestAgent

--- a/all/agents/vpg.py
+++ b/all/agents/vpg.py
@@ -2,6 +2,7 @@ import torch
 from torch.nn.functional import mse_loss
 from all.core import State
 from ._agent import Agent
+from .a2c import A2CTestAgent
 
 
 class VPG(Agent):
@@ -130,3 +131,5 @@ class VPG(Agent):
             returns[t] = discounted_return
             t -= 1
         return returns
+
+VPGTestAgent = A2CTestAgent

--- a/all/agents/vpg.py
+++ b/all/agents/vpg.py
@@ -132,4 +132,5 @@ class VPG(Agent):
             t -= 1
         return returns
 
+
 VPGTestAgent = A2CTestAgent

--- a/all/agents/vqn.py
+++ b/all/agents/vqn.py
@@ -48,4 +48,5 @@ class VQN(Agent):
             # backward pass
             self.q.reinforce(loss)
 
+
 VQNTestAgent = DQNTestAgent

--- a/all/agents/vqn.py
+++ b/all/agents/vqn.py
@@ -1,6 +1,7 @@
 import torch
 from torch.nn.functional import mse_loss
 from ._agent import Agent
+from .dqn import DQNTestAgent
 
 
 class VQN(Agent):
@@ -46,3 +47,5 @@ class VQN(Agent):
             loss = mse_loss(value, target)
             # backward pass
             self.q.reinforce(loss)
+
+VQNTestAgent = DQNTestAgent

--- a/all/agents/vsarsa.py
+++ b/all/agents/vsarsa.py
@@ -1,5 +1,6 @@
 from torch.nn.functional import mse_loss
 from ._agent import Agent
+from .dqn import DQNTestAgent
 
 
 class VSarsa(Agent):
@@ -43,3 +44,5 @@ class VSarsa(Agent):
             loss = mse_loss(value, target)
             # backward pass
             self.q.reinforce(loss)
+
+VSarsaTestAgent = DQNTestAgent

--- a/all/agents/vsarsa.py
+++ b/all/agents/vsarsa.py
@@ -45,4 +45,5 @@ class VSarsa(Agent):
             # backward pass
             self.q.reinforce(loss)
 
+
 VSarsaTestAgent = DQNTestAgent

--- a/all/approximation/approximation.py
+++ b/all/approximation/approximation.py
@@ -3,7 +3,7 @@ import torch
 from torch.nn import utils
 from all.logging import DummyWriter
 from .target import TrivialTarget
-from .checkpointer import PeriodicCheckpointer
+from .checkpointer import DummyCheckpointer
 
 DEFAULT_CHECKPOINT_FREQUENCY = 200
 
@@ -74,7 +74,7 @@ class Approximation():
         self._name = name
 
         if checkpointer is None:
-            checkpointer = PeriodicCheckpointer(DEFAULT_CHECKPOINT_FREQUENCY)
+            checkpointer = DummyCheckpointer()
         self._checkpointer = checkpointer
         self._checkpointer.init(
             self.model,

--- a/all/approximation/approximation.py
+++ b/all/approximation/approximation.py
@@ -51,7 +51,7 @@ class Approximation():
     def __init__(
             self,
             model,
-            optimizer,
+            optimizer=None,
             checkpointer=None,
             clip_grad=0,
             loss_scaling=1,

--- a/all/approximation/q_network.py
+++ b/all/approximation/q_network.py
@@ -7,7 +7,7 @@ class QNetwork(Approximation):
     def __init__(
             self,
             model,
-            optimizer,
+            optimizer=None,
             name='q',
             **kwargs
     ):

--- a/all/experiments/__init__.py
+++ b/all/experiments/__init__.py
@@ -5,7 +5,7 @@ from .parallel_env_experiment import ParallelEnvExperiment
 from .writer import ExperimentWriter
 from .plots import plot_returns_100
 from .slurm import SlurmExperiment
-from .watch import GreedyAgent, watch, load_and_watch
+from .watch import watch, load_and_watch
 
 __all__ = [
     "run_experiment",
@@ -13,7 +13,6 @@ __all__ = [
     "SingleEnvExperiment",
     "ParallelEnvExperiment",
     "SlurmExperiment",
-    "GreedyAgent",
     "ExperimentWriter",
     "watch",
     "load_and_watch",

--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import numpy as np
+from scipy import stats
 import torch
 
 
@@ -74,6 +75,8 @@ class Experiment(ABC):
             print('test episode: {}, returns: {}'.format(episode, returns))
 
     def _log_test(self, returns):
+        if not self._quiet:
+            print('test returns (mean ± sem): {} ± {}'.format(np.mean(returns), stats.sem(returns)))
         self._writer.add_summary('returns-test', np.mean(returns), np.std(returns))
 
     def save(self):

--- a/all/experiments/experiment.py
+++ b/all/experiments/experiment.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import numpy as np
+import torch
 
 
 class Experiment(ABC):
@@ -74,3 +75,6 @@ class Experiment(ABC):
 
     def _log_test(self, returns):
         self._writer.add_summary('returns-test', np.mean(returns), np.std(returns))
+
+    def save(self):
+        return self._preset.save('{}/preset.pt'.format(self._writer.log_dir))

--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -14,13 +14,14 @@ class ParallelEnvExperiment(Experiment):
             self,
             preset,
             env,
+            name=None,
             train_steps=float('inf'),
             logdir='runs',
             quiet=False,
             render=False,
             write_loss=True
     ):
-        self._name = preset.__class__.__name__
+        self._name = name if name is not None else preset.__class__.__name__
         super().__init__(self._make_writer(logdir, self._name, env.name, write_loss), quiet)
         self._n_envs = preset.n_envs
         self._envs = env.duplicate(self._n_envs)

--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -59,11 +59,14 @@ class ParallelEnvExperiment(Experiment):
             self._step()
 
     def test(self, episodes=100):
-        self._test_reset(episodes)
-        while len(self._test_returns) < episodes:
-            self._test_step()
-        self._log_test(self._test_returns)
-        return self._test_returns
+        test_agent = self._preset.test_agent()
+        returns = []
+        for episode in range(episodes):
+            episode_return = self._run_test_episode(test_agent)
+            returns.append(episode_return)
+            self._log_test_episode(episode, episode_return)
+        self._log_test(returns)
+        return returns
 
     def _reset(self):
         for env in self._envs:
@@ -103,40 +106,6 @@ class ParallelEnvExperiment(Experiment):
                     env.step(action)
                     self._frame += 1
 
-    def _test_reset(self, episodes):
-        self._reset()
-        self._test_episodes = episodes
-        self._test_episodes_started = 0
-        self._test_returns = []
-        self._should_save_returns = [True] * self._n_envs
-        self._test_agent = self._preset.test_agent()
-
-    def _test_step(self):
-        states = self._aggregate_states()
-        actions = self._test_agent.act(states)
-        self._test_step_envs(actions)
-
-    def _test_step_envs(self, actions):
-        for i, env in enumerate(self._envs):
-            state = env.state
-            if self._render:
-                env.render()
-            if state.done:
-                self._returns[i] += state.reward
-                if self._should_save_returns[i]:
-                    self._test_returns.append(self._returns[i].item())
-                    self._log_test_episode(len(self._test_returns), self._returns[i].item())
-                if self._test_episodes_started > self._test_episodes:
-                    self._should_save_returns[i] = False
-                env.reset()
-                self._returns[i] = 0
-                self._test_episodes_started += 1
-            else:
-                action = actions[i]
-                if action is not None:
-                    self._returns[i] += state.reward
-                    env.step(action)
-
     def _aggregate_states(self):
         return State.array([env.state for env in self._envs])
 
@@ -146,6 +115,23 @@ class ParallelEnvExperiment(Experiment):
             dtype=torch.float,
             device=self._envs[0].device
         )
+
+    def _run_test_episode(self, test_agent):
+        # initialize the episode
+        env = self._envs[0].duplicate(1)[0]
+        state = env.reset()
+        action = test_agent.act(state)
+        returns = 0
+
+        # loop until the episode is finished
+        while not state.done:
+            if self._render:
+                env.render()
+            state = env.step(action)
+            action = test_agent.act(state)
+            returns += state.reward
+
+        return returns
 
     def _fps(self, i):
         end_time = timer()

--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -14,6 +14,7 @@ class ParallelEnvExperiment(Experiment):
             self,
             preset,
             env,
+            train_steps=float('inf'),
             logdir='runs',
             quiet=False,
             render=False,
@@ -24,7 +25,7 @@ class ParallelEnvExperiment(Experiment):
         self._n_envs = preset.n_envs
         self._envs = env.duplicate(self._n_envs)
         self._preset = preset
-        self._agent = preset.agent(writer=self._writer)
+        self._agent = preset.agent(writer=self._writer, train_steps=train_steps)
         self._render = render
 
         # training state

--- a/all/experiments/parallel_env_experiment_test.py
+++ b/all/experiments/parallel_env_experiment_test.py
@@ -64,5 +64,6 @@ class TestParallelEnvExperiment(unittest.TestCase):
     def make_agent(self):
         return a2c().device('cpu').env(self.env).build()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/all/experiments/parallel_env_experiment_test.py
+++ b/all/experiments/parallel_env_experiment_test.py
@@ -13,17 +13,23 @@ class MockExperiment(ParallelEnvExperiment):
         return self._writer
 
 
-class TestParalleleEnvExperiment(unittest.TestCase):
+class TestParallelEnvExperiment(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
         torch.manual_seed(0)
         self.env = GymEnvironment('CartPole-v0')
-        self.experiment = MockExperiment(a2c(), self.env, quiet=True)
+        self.env.seed(0)
+        self.experiment = MockExperiment(self.make_agent(), self.env, quiet=True)
         for i, env in enumerate(self.experiment._envs):
             env.seed(i)
 
-    def test_adds_label(self):
-        self.assertEqual(self.experiment._writer.label, "_a2c_CartPole-v0")
+    def test_adds_default_label(self):
+        self.assertEqual(self.experiment._writer.label, "A2CClassicControlPreset_CartPole-v0")
+
+    def test_adds_custom_label(self):
+        env = GymEnvironment('CartPole-v0')
+        experiment = MockExperiment(self.make_agent(), env, name='a2c', quiet=True)
+        self.assertEqual(experiment._writer.label, "a2c_CartPole-v0")
 
     def test_writes_training_returns_eps(self):
         self.experiment.train(episodes=3)
@@ -39,28 +45,24 @@ class TestParalleleEnvExperiment(unittest.TestCase):
     def test_writes_test_returns(self):
         self.experiment.train(episodes=5)
         returns = self.experiment.test(episodes=4)
-        expected_mean = 9.5
-        expected_std = 0.8660254037844386
-        np.testing.assert_equal(np.mean(returns), expected_mean)
+        self.assertEqual(len(returns), 4)
         np.testing.assert_equal(
             self.experiment._writer.data["evaluation/returns-test/mean"]["values"],
-            np.array([expected_mean]),
+            np.array([np.mean(returns)]),
         )
         np.testing.assert_equal(
             self.experiment._writer.data["evaluation/returns-test/std"]["values"],
-            np.array([expected_std]),
-        )
-        np.testing.assert_equal(
-            self.experiment._writer.data["evaluation/returns-test/mean"]["steps"],
-            np.array([104.]),
+            np.array([np.std(returns)]),
         )
 
     def test_writes_loss(self):
-        experiment = MockExperiment(a2c(), self.env, quiet=True, write_loss=True)
+        experiment = MockExperiment(self.make_agent(), self.env, quiet=True, write_loss=True)
         self.assertTrue(experiment._writer.write_loss)
-        experiment = MockExperiment(a2c(), self.env, quiet=True, write_loss=False)
+        experiment = MockExperiment(self.make_agent(), self.env, quiet=True, write_loss=False)
         self.assertFalse(experiment._writer.write_loss)
 
+    def make_agent(self):
+        return a2c().device('cpu').env(self.env).build()
 
 if __name__ == "__main__":
     unittest.main()

--- a/all/experiments/run_experiment.py
+++ b/all/experiments/run_experiment.py
@@ -25,6 +25,7 @@ def run_experiment(
             experiment = make_experiment(
                 preset,
                 env,
+                train_steps=frames,
                 logdir=logdir,
                 quiet=quiet,
                 render=render,

--- a/all/experiments/run_experiment.py
+++ b/all/experiments/run_experiment.py
@@ -20,7 +20,8 @@ def run_experiment(
 
     for env in envs:
         for agent in agents:
-            make_experiment = get_experiment_type(agent)
+            make_experiment = SingleEnvExperiment
+            # make_experiment = get_experiment_type(agent)
             experiment = make_experiment(
                 agent,
                 env,
@@ -31,6 +32,7 @@ def run_experiment(
             )
             experiment.train(frames=frames)
             experiment.test(episodes=test_episodes)
+            experiment.save()
 
 
 def get_experiment_type(agent):

--- a/all/experiments/run_experiment.py
+++ b/all/experiments/run_experiment.py
@@ -19,11 +19,11 @@ def run_experiment(
         envs = [envs]
 
     for env in envs:
-        for agent in agents:
-            make_experiment = SingleEnvExperiment
-            # make_experiment = get_experiment_type(agent)
+        for preset_builder in agents:
+            preset = preset_builder.env(env).build()
+            make_experiment = get_experiment_type(preset)
             experiment = make_experiment(
-                agent,
+                preset,
                 env,
                 logdir=logdir,
                 quiet=quiet,
@@ -35,8 +35,8 @@ def run_experiment(
             experiment.save()
 
 
-def get_experiment_type(agent):
-    if is_parallel_env_agent(agent):
+def get_experiment_type(preset):
+    if preset.is_parallel():
         return ParallelEnvExperiment
     return SingleEnvExperiment
 

--- a/all/experiments/single_env_experiment.py
+++ b/all/experiments/single_env_experiment.py
@@ -9,17 +9,17 @@ class SingleEnvExperiment(Experiment):
 
     def __init__(
             self,
-            agent,
+            preset,
             env,
             logdir='runs',
             quiet=False,
             render=False,
             write_loss=True
     ):
-        self._name = agent.__class__.__name__
+        self._name = preset.__class__.__name__
         super().__init__(self._make_writer(logdir, self._name, env.name, write_loss), quiet)
         self._logdir = logdir
-        self._preset = agent.env(env).build()
+        self._preset = preset
         self._agent = self._preset.agent()
         self._env = env
         self._render = render
@@ -50,9 +50,6 @@ class SingleEnvExperiment(Experiment):
             self._log_test_episode(episode, episode_return)
         self._log_test(returns)
         return returns
-
-    def save(self):
-        return self._preset.save('{}/preset.pt'.format(self._writer.log_dir))
 
     def _run_training_episode(self):
         # initialize timer

--- a/all/experiments/single_env_experiment.py
+++ b/all/experiments/single_env_experiment.py
@@ -11,6 +11,7 @@ class SingleEnvExperiment(Experiment):
             self,
             preset,
             env,
+            train_steps=float('inf'),
             logdir='runs',
             quiet=False,
             render=False,
@@ -20,7 +21,7 @@ class SingleEnvExperiment(Experiment):
         super().__init__(self._make_writer(logdir, self._name, env.name, write_loss), quiet)
         self._logdir = logdir
         self._preset = preset
-        self._agent = self._preset.agent()
+        self._agent = self._preset.agent(writer=self._writer, train_steps=train_steps)
         self._env = env
         self._render = render
         self._frame = 1

--- a/all/experiments/single_env_experiment.py
+++ b/all/experiments/single_env_experiment.py
@@ -11,13 +11,14 @@ class SingleEnvExperiment(Experiment):
             self,
             preset,
             env,
+            name=None,
             train_steps=float('inf'),
             logdir='runs',
             quiet=False,
             render=False,
             write_loss=True
     ):
-        self._name = preset.__class__.__name__
+        self._name = name if name is not None else preset.__class__.__name__
         super().__init__(self._make_writer(logdir, self._name, env.name, write_loss), quiet)
         self._logdir = logdir
         self._preset = preset

--- a/all/experiments/single_env_experiment_test.py
+++ b/all/experiments/single_env_experiment_test.py
@@ -104,5 +104,6 @@ class TestSingleEnvExperiment(unittest.TestCase):
     def make_preset(self):
         return dqn().device('cpu').env(self.env).build()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/all/experiments/single_env_experiment_test.py
+++ b/all/experiments/single_env_experiment_test.py
@@ -55,12 +55,16 @@ class TestSingleEnvExperiment(unittest.TestCase):
         self.env.seed(0)
         self.experiment = None
 
-    def test_adds_label(self):
-        experiment = MockExperiment(dqn(), self.env, quiet=True)
-        self.assertEqual(experiment._writer.label, "_dqn_CartPole-v0")
+    def test_adds_default_name(self):
+        experiment = MockExperiment(self.make_preset(), self.env, quiet=True)
+        self.assertEqual(experiment._writer.label, "DQNClassicControlPreset_CartPole-v0")
+
+    def test_adds_custom_name(self):
+        experiment = MockExperiment(self.make_preset(), self.env, name='dqn', quiet=True)
+        self.assertEqual(experiment._writer.label, "dqn_CartPole-v0")
 
     def test_writes_training_returns_eps(self):
-        experiment = MockExperiment(dqn(), self.env, quiet=True)
+        experiment = MockExperiment(self.make_preset(), self.env, quiet=True)
         experiment.train(episodes=3)
         np.testing.assert_equal(
             experiment._writer.data["evaluation/returns/episode"]["values"],
@@ -72,7 +76,7 @@ class TestSingleEnvExperiment(unittest.TestCase):
         )
 
     def test_writes_test_returns(self):
-        experiment = MockExperiment(dqn(), self.env, quiet=True)
+        experiment = MockExperiment(self.make_preset(), self.env, quiet=True)
         experiment.train(episodes=5)
         returns = experiment.test(episodes=4)
         expected_mean = 9.5
@@ -92,11 +96,13 @@ class TestSingleEnvExperiment(unittest.TestCase):
         )
 
     def test_writes_loss(self):
-        experiment = MockExperiment(dqn(), self.env, quiet=True, write_loss=True)
+        experiment = MockExperiment(self.make_preset(), self.env, quiet=True, write_loss=True)
         self.assertTrue(experiment._writer.write_loss)
-        experiment = MockExperiment(dqn(), self.env, quiet=True, write_loss=False)
+        experiment = MockExperiment(self.make_preset(), self.env, quiet=True, write_loss=False)
         self.assertFalse(experiment._writer.write_loss)
 
+    def make_preset(self):
+        return dqn().device('cpu').env(self.env).build()
 
 if __name__ == "__main__":
     unittest.main()

--- a/all/experiments/watch.py
+++ b/all/experiments/watch.py
@@ -10,92 +10,23 @@ def watch(agent, env, fps=60):
     returns = 0
     # have to call this before initial reset for pybullet envs
     env.render(mode="human")
+    env.reset()
+
+    print(env.state)
     while True:
+        action = agent.act(env.state)
+        returns += env.state.reward
+
         time.sleep(1 / fps)
-        if env.done:
+        if env.state.done:
             print('returns:', returns)
             env.reset()
             returns = 0
         else:
             env.step(action)
         env.render()
-        action = agent.act(env.state, env.reward)
-        returns += env.reward
 
 
-def load_and_watch(dir, env, fps=60):
-    watch(GreedyAgent.load(dir, env), env, fps=fps)
-
-
-class GreedyAgent(Agent):
-    def __init__(
-            self,
-            action_space,
-            feature=None,
-            q=None,
-            policy=None
-    ):
-        self.action_space = action_space
-        self.feature = feature
-        self.policy = None
-        if policy:
-            self.policy = policy
-        else:
-            self.policy = q
-        if not self.policy:
-            raise TypeError('GreedyAgent must have either policy or q function')
-
-    def act(self, state, _):
-        with torch.no_grad():
-            if self.feature:
-                state = self.feature(state)
-            if isinstance(self.action_space, gym.spaces.Discrete):
-                return self.choose_discrete(state)
-            if isinstance(self.action_space, gym.spaces.Box):
-                return self.choose_continuous(state)
-            raise TypeError('Unknown action space')
-
-    def eval(self, state, reward):
-        return self.act(state, reward)
-
-    def choose_discrete(self, state):
-        ret = self.policy(state)
-        if isinstance(ret, torch.Tensor):
-            if len(ret.shape) == 3:  # categorical dqn
-                return torch.argmax((ret * self.policy.atoms).sum(dim=2), dim=1)
-            return torch.argmax(self.policy(state), dim=1)
-        if isinstance(ret, torch.distributions.distribution.Distribution):
-            return ret.sample()
-        return ret  # unknown type, return it and pray!
-
-    def choose_continuous(self, state):
-        ret = self.policy(state)
-        if isinstance(ret, torch.Tensor):
-            return ret
-        if isinstance(ret, tuple):
-            return ret[0]
-        if isinstance(ret, torch.distributions.distribution.Distribution):
-            return ret.sample()
-        return ret  # unknown type, return it and pray!
-
-    @staticmethod
-    def load(dirname, env):
-        feature = None
-        policy = None
-        q = None
-        for filename in os.listdir(dirname):
-            if filename == 'feature.pt':
-                feature = torch.load(os.path.join(dirname, filename)).to(env.device)
-            if filename == 'policy.pt':
-                policy = torch.load(os.path.join(dirname, filename)).to(env.device)
-            if filename in ('q.pt', 'q_dist.pt'):
-                q = torch.load(os.path.join(dirname, filename)).to(env.device)
-
-        agent = GreedyAgent(
-            env.action_space,
-            feature=feature,
-            policy=policy,
-            q=q,
-        )
-
-        return agent
+def load_and_watch(filename, env, fps=60):
+    agent = torch.load(filename).test_agent()
+    watch(agent, env, fps=fps)

--- a/all/experiments/watch.py
+++ b/all/experiments/watch.py
@@ -12,7 +12,6 @@ def watch(agent, env, fps=60):
     env.render(mode="human")
     env.reset()
 
-    print(env.state)
     while True:
         action = agent.act(env.state)
         returns += env.state.reward

--- a/all/policies/deterministic.py
+++ b/all/policies/deterministic.py
@@ -20,8 +20,8 @@ class DeterministicPolicy(Approximation):
     def __init__(
             self,
             model,
-            optimizer,
-            space,
+            optimizer=None,
+            space=None,
             name='policy',
             **kwargs
     ):

--- a/all/policies/gaussian.py
+++ b/all/policies/gaussian.py
@@ -28,8 +28,8 @@ class GaussianPolicy(Approximation):
     def __init__(
             self,
             model,
-            optimizer,
-            space,
+            optimizer=None,
+            space=None,
             name='policy',
             **kwargs
     ):
@@ -49,13 +49,9 @@ class GaussianPolicyNetwork(RLNetwork):
 
     def forward(self, state):
         outputs = super().forward(state)
-        action_dim = outputs.shape[1] // 2
-        means = self._squash(outputs[:, 0:action_dim])
-
-        if not self.training:
-            return means
-
-        logvars = outputs[:, action_dim:] * self._scale
+        action_dim = outputs.shape[-1] // 2
+        means = self._squash(outputs[..., 0:action_dim])
+        logvars = outputs[..., action_dim:] * self._scale
         std = logvars.exp_()
         return Independent(Normal(means, std), 1)
 

--- a/all/policies/gaussian_test.py
+++ b/all/policies/gaussian_test.py
@@ -62,8 +62,8 @@ class TestGaussian(unittest.TestCase):
         dist = self.policy.no_grad(state)
         tt.assert_almost_equal(dist.mean, torch.tensor([[-0.233, 0.459, -0.058]]), decimal=3)
         tt.assert_almost_equal(dist.entropy(), torch.tensor([4.251]), decimal=3)
-        best = self.policy.eval(state)
-        tt.assert_almost_equal(best, torch.tensor([[-0.233, 0.459, -0.058]]), decimal=3)
+        best = self.policy.eval(state).sample()
+        tt.assert_almost_equal(best, torch.tensor([[-0.977, -1.05, 0.311]]), decimal=3)
 
 
 if __name__ == '__main__':

--- a/all/policies/soft_deterministic.py
+++ b/all/policies/soft_deterministic.py
@@ -22,8 +22,8 @@ class SoftDeterministicPolicy(Approximation):
     def __init__(
             self,
             model,
-            optimizer,
-            space,
+            optimizer=None,
+            space=None,
             name="policy",
             **kwargs
     ):

--- a/all/policies/softmax.py
+++ b/all/policies/softmax.py
@@ -20,7 +20,7 @@ class SoftmaxPolicy(Approximation):
     def __init__(
             self,
             model,
-            optimizer,
+            optimizer=None,
             name='policy',
             **kwargs
     ):
@@ -35,6 +35,4 @@ class SoftmaxPolicyNetwork(RLNetwork):
     def forward(self, state):
         outputs = super().forward(state)
         probs = functional.softmax(outputs, dim=-1)
-        if self.training:
-            return torch.distributions.Categorical(probs)
-        return torch.argmax(probs, dim=-1)
+        return torch.distributions.Categorical(probs)

--- a/all/policies/softmax_test.py
+++ b/all/policies/softmax_test.py
@@ -79,7 +79,7 @@ class TestSoftmax(unittest.TestCase):
             [0.266, 0.196, 0.538],
             [0.469, 0.227, 0.304]
         ]), decimal=3)
-        best = self.policy.eval(states)
+        best = self.policy.eval(states).sample()
         tt.assert_equal(best, torch.tensor([2, 2, 0]))
 
 

--- a/all/presets/__init__.py
+++ b/all/presets/__init__.py
@@ -1,5 +1,7 @@
+
 from all.presets import atari
 from all.presets import classic_control
 from all.presets import continuous
+from .preset import Preset
 
-__all__ = ["atari", "classic_control", "continuous"]
+__all__ = ["Preset", "atari", "classic_control", "continuous"]

--- a/all/presets/atari/__init__.py
+++ b/all/presets/atari/__init__.py
@@ -8,6 +8,7 @@ from .vac import vac, VACAtariPreset
 from .vpg import vpg, VPGAtariPreset
 from .vqn import vqn, VQNAtariPreset
 from .vsarsa import vsarsa, VSarsaAtariPreset
+from .preset import Preset
 
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "VQNAtariPreset",
     "vsarsa",
     "VSarsaAtariPreset",
+    "Preset"
 ]

--- a/all/presets/atari/__init__.py
+++ b/all/presets/atari/__init__.py
@@ -1,23 +1,34 @@
-from .a2c import a2c
-from .c51 import c51
-from .dqn import dqn
-from .ddqn import ddqn
-from .ppo import ppo
-from .rainbow import rainbow
-from .vac import vac
-from .vpg import vpg
-from .vqn import vqn
-from .vsarsa import vsarsa
+from .a2c import a2c, A2CAtariPreset
+from .c51 import c51, C51AtariPreset
+from .dqn import dqn, DQNAtariPreset
+from .ddqn import ddqn, DDQNAtariPreset
+from .ppo import ppo, PPOAtariPreset
+from .rainbow import rainbow, RainbowAtariPreset
+from .vac import vac, VACAtariPreset
+from .vpg import vpg, VPGAtariPreset
+from .vqn import vqn, VQNAtariPreset
+from .vsarsa import vsarsa, VSarsaAtariPreset
+
 
 __all__ = [
     "a2c",
+    "A2CAtariPreset",
     "c51",
+    "C51AtariPreset",
     "ddqn",
+    "DDQNAtariPreset",
     "dqn",
+    "DQNAtariPreset",
     "ppo",
+    "PPOAtariPreset",
     "rainbow",
+    "RainbowAtariPreset",
     "vac",
+    "VACAtariPreset",
     "vpg",
+    "VPGAtariPreset",
     "vqn",
+    "VQNAtariPreset",
     "vsarsa",
+    "VSarsaAtariPreset",
 ]

--- a/all/presets/atari/__init__.py
+++ b/all/presets/atari/__init__.py
@@ -8,7 +8,6 @@ from .vac import vac, VACAtariPreset
 from .vpg import vpg, VPGAtariPreset
 from .vqn import vqn, VQNAtariPreset
 from .vsarsa import vsarsa, VSarsaAtariPreset
-from .preset import Preset
 
 
 __all__ = [
@@ -32,5 +31,4 @@ __all__ = [
     "VQNAtariPreset",
     "vsarsa",
     "VSarsaAtariPreset",
-    "Preset"
 ]

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -1,40 +1,37 @@
+import math
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
-from all.agents import A2C
+from all.agents import A2C, A2CTestAgent
 from all.bodies import DeepmindAtariBody
 from all.approximation import VNetwork, FeatureNetwork
 from all.logging import DummyWriter
 from all.policies import SoftmaxPolicy
 from .models import nature_features, nature_value_head, nature_policy_head
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def a2c(
-        # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        last_frame=40e6,
-        # Adam optimizer settings
-        lr=7e-4,
-        eps=1.5e-4,
-        # Other optimization settings
-        clip_grad=0.1,
-        entropy_loss_scaling=0.01,
-        value_loss_scaling=0.5,
-        # Batch settings
-        n_envs=16,
-        n_steps=5,
-        # Model construction
-        feature_model_constructor=nature_features,
-        value_model_constructor=nature_value_head,
-        policy_model_constructor=nature_policy_head
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 7e-4,
+    "eps": 1.5e-4,
+    # Other optimization settings
+    "clip_grad": 0.1,
+    "entropy_loss_scaling": 0.01,
+    "value_loss_scaling": 0.5,
+    # Batch settings
+    "n_envs": 16,
+    "n_steps": 5,
+}
+
+class A2CPreset(Preset):
     """
     A2C Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         clip_grad (float): The maximum magnitude of the gradient for any given parameter.
@@ -43,51 +40,51 @@ def a2c(
         value_loss_scaling (float): Coefficient for the value function loss.
         n_envs (int): Number of parallel environments.
         n_steps (int): Length of each rollout.
-        feature_model_constructor (function): The function used to construct the neural feature model.
-        value_model_constructor (function): The function used to construct the neural value model.
-        policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _a2c(envs, writer=DummyWriter()):
-        env = envs[0]
-        final_anneal_step = last_frame / (n_steps * n_envs * 4)
+    def __init__(self, hyperparameters, env, device):
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.value_model = nature_value_head().to(device)
+        self.policy_model = nature_policy_head(env).to(device)
+        self.feature_model = nature_features().to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
 
-        value_model = value_model_constructor().to(device)
-        policy_model = policy_model_constructor(env).to(device)
-        feature_model = feature_model_constructor().to(device)
-
-        feature_optimizer = Adam(feature_model.parameters(), lr=lr, eps=eps)
-        value_optimizer = Adam(value_model.parameters(), lr=lr, eps=eps)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr, eps=eps)
+    def agent(self, writer=DummyWriter()):
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
 
         features = FeatureNetwork(
-            feature_model,
+            self.feature_model,
             feature_optimizer,
-            scheduler=CosineAnnealingLR(
-                feature_optimizer,
-                final_anneal_step,
-            ),
-            clip_grad=clip_grad,
+            # scheduler=CosineAnnealingLR(
+            #     feature_optimizer,
+            #     final_anneal_step,
+            # ),
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         v = VNetwork(
-            value_model,
+            self.value_model,
             value_optimizer,
-            scheduler=CosineAnnealingLR(
-                value_optimizer,
-                final_anneal_step,
-            ),
-            loss_scaling=value_loss_scaling,
-            clip_grad=clip_grad,
+            # scheduler=CosineAnnealingLR(
+            #     value_optimizer,
+            #     final_anneal_step,
+            # ),
+            loss_scaling=self.hyperparameters["value_loss_scaling"],
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         policy = SoftmaxPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
-            scheduler=CosineAnnealingLR(
-                policy_optimizer,
-                final_anneal_step,
-            ),
-            clip_grad=clip_grad,
+            # scheduler=CosineAnnealingLR(
+            #     policy_optimizer,
+            #     final_anneal_step,
+            # ),
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
 
@@ -96,15 +93,18 @@ def a2c(
                 features,
                 v,
                 policy,
-                n_envs=n_envs,
-                n_steps=n_steps,
-                discount_factor=discount_factor,
-                entropy_loss_scaling=entropy_loss_scaling,
+                n_envs=self.hyperparameters["n_envs"],
+                n_steps=self.hyperparameters["n_steps"],
+                discount_factor=self.hyperparameters["discount_factor"],
+                entropy_loss_scaling=self.hyperparameters["entropy_loss_scaling"],
                 writer=writer
             ),
         )
 
-    return _a2c, n_envs
+    def test_agent(self):
+        return DeepmindAtariBody(A2CTestAgent(self.feature_model, self.policy_model))
 
+    def n_envs(self):
+        return self.hyperparameters['n_envs']
 
-__all__ = ["a2c"]
+a2c = preset_builder('a2c', default_hyperparameters, A2CPreset)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -31,6 +31,7 @@ default_hyperparameters = {
     "policy_model_constructor": nature_policy_head
 }
 
+
 class A2CAtariPreset(Preset):
     """
     Advantage Actor-Critic (A2C) Atari preset.
@@ -38,7 +39,7 @@ class A2CAtariPreset(Preset):
     Args:
         env (all.environments.AtariEnvironment): The environment for which to construct the agent.
         device (torch.device, optional): the device on which to load the agent
-    
+
     Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
@@ -53,6 +54,7 @@ class A2CAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -111,5 +113,6 @@ class A2CAtariPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return DeepmindAtariBody(A2CTestAgent(features, policy))
+
 
 a2c = preset_builder('a2c', default_hyperparameters, A2CAtariPreset)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -102,13 +102,4 @@ class A2CAtariPreset(Preset):
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return DeepmindAtariBody(A2CTestAgent(features, policy))
 
-    def n_envs(self):
-        return self.hyperparameters['n_envs']
-
-'''
-blah blah
-
-Args:
-    blah: blah
-'''
 a2c = preset_builder('a2c', default_hyperparameters, A2CAtariPreset)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -33,10 +33,10 @@ default_hyperparameters = {
 
 class A2CAtariPreset(Preset):
     """
-    A2C Atari preset.
+    Advantage Actor-Critic (A2C) Atari preset.
 
     Args:
-        env (all.environments.AtariEnvironment): The device
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
         device (torch.device, optional): the device on which to load the agent
     
     Keyword Args:

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -32,15 +32,17 @@ class A2CAtariPreset(Preset):
     A2C Atari preset.
 
     Args:
-        discount_factor (float): Discount factor for future rewards.
-        lr (float): Learning rate for the Adam optimizer.
-        eps (float): Stability parameters for the Adam optimizer.
-        clip_grad (float): The maximum magnitude of the gradient for any given parameter.
-            Set to 0 to disable.
-        entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
-        value_loss_scaling (float): Coefficient for the value function loss.
-        n_envs (int): Number of parallel environments.
-        n_steps (int): Length of each rollout.
+            env (all.environments.AtariEnvironment): The device
+            device (torch.device): the device on which to load the agent
+            discount_factor (float): Discount factor for future rewards.
+            lr (float): Learning rate for the Adam optimizer.
+            eps (float): Stability parameters for the Adam optimizer.
+            clip_grad (float): The maximum magnitude of the gradient for any given parameter.
+                Set to 0 to disable.
+            entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
+            value_loss_scaling (float): Coefficient for the value function loss.
+            n_envs (int): Number of parallel environments.
+            n_steps (int): Length of each rollout.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -103,4 +105,10 @@ class A2CAtariPreset(Preset):
     def n_envs(self):
         return self.hyperparameters['n_envs']
 
+'''
+blah blah
+
+Args:
+    blah: blah
+'''
 a2c = preset_builder('a2c', default_hyperparameters, A2CAtariPreset)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -50,7 +50,9 @@ class A2CAtariPreset(Preset):
         self.hyperparameters = hyperparameters
         self.device = device
 
-    def agent(self, writer=DummyWriter()):
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps / (self.hyperparameters['n_steps'] * self.hyperparameters['n_envs'])
+
         feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
         value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
         policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
@@ -58,10 +60,7 @@ class A2CAtariPreset(Preset):
         features = FeatureNetwork(
             self.feature_model,
             feature_optimizer,
-            # scheduler=CosineAnnealingLR(
-            #     feature_optimizer,
-            #     final_anneal_step,
-            # ),
+            scheduler=CosineAnnealingLR(feature_optimizer, n_updates),
             clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
@@ -69,10 +68,7 @@ class A2CAtariPreset(Preset):
         v = VNetwork(
             self.value_model,
             value_optimizer,
-            # scheduler=CosineAnnealingLR(
-            #     value_optimizer,
-            #     final_anneal_step,
-            # ),
+            scheduler=CosineAnnealingLR(value_optimizer, n_updates),
             loss_scaling=self.hyperparameters["value_loss_scaling"],
             clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
@@ -81,10 +77,7 @@ class A2CAtariPreset(Preset):
         policy = SoftmaxPolicy(
             self.policy_model,
             policy_optimizer,
-            # scheduler=CosineAnnealingLR(
-            #     policy_optimizer,
-            #     final_anneal_step,
-            # ),
+            scheduler=CosineAnnealingLR(policy_optimizer, n_updates),
             clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -42,7 +42,7 @@ class A2CAtariPreset(Preset):
         n_envs (int): Number of parallel environments.
         n_steps (int): Length of each rollout.
     """
-    def __init__(self, hyperparameters, env, device):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.value_model = nature_value_head().to(device)
         self.policy_model = nature_policy_head(env).to(device)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -27,7 +27,7 @@ default_hyperparameters = {
     "n_steps": 5,
 }
 
-class A2CPreset(Preset):
+class A2CAtariPreset(Preset):
     """
     A2C Atari preset.
 
@@ -110,4 +110,4 @@ class A2CPreset(Preset):
     def n_envs(self):
         return self.hyperparameters['n_envs']
 
-a2c = preset_builder('a2c', default_hyperparameters, A2CPreset)
+a2c = preset_builder('a2c', default_hyperparameters, A2CAtariPreset)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -1,3 +1,4 @@
+import copy
 import math
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
@@ -102,7 +103,9 @@ class A2CPreset(Preset):
         )
 
     def test_agent(self):
-        return DeepmindAtariBody(A2CTestAgent(self.feature_model, self.policy_model))
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
+        return DeepmindAtariBody(A2CTestAgent(features, policy))
 
     def n_envs(self):
         return self.hyperparameters['n_envs']

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -37,7 +37,9 @@ class A2CAtariPreset(Preset):
 
     Args:
         env (all.environments.AtariEnvironment): The device
-        device (torch.device): the device on which to load the agent
+        device (torch.device, optional): the device on which to load the agent
+    
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
@@ -52,6 +54,7 @@ class A2CAtariPreset(Preset):
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.value_model = hyperparameters['value_model_constructor']().to(device)
         self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)

--- a/all/presets/atari/a2c.py
+++ b/all/presets/atari/a2c.py
@@ -25,6 +25,10 @@ default_hyperparameters = {
     # Batch settings
     "n_envs": 16,
     "n_steps": 5,
+    # Model construction
+    "feature_model_constructor": nature_features,
+    "value_model_constructor": nature_value_head,
+    "policy_model_constructor": nature_policy_head
 }
 
 class A2CAtariPreset(Preset):
@@ -32,23 +36,26 @@ class A2CAtariPreset(Preset):
     A2C Atari preset.
 
     Args:
-            env (all.environments.AtariEnvironment): The device
-            device (torch.device): the device on which to load the agent
-            discount_factor (float): Discount factor for future rewards.
-            lr (float): Learning rate for the Adam optimizer.
-            eps (float): Stability parameters for the Adam optimizer.
-            clip_grad (float): The maximum magnitude of the gradient for any given parameter.
-                Set to 0 to disable.
-            entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
-            value_loss_scaling (float): Coefficient for the value function loss.
-            n_envs (int): Number of parallel environments.
-            n_steps (int): Length of each rollout.
+        env (all.environments.AtariEnvironment): The device
+        device (torch.device): the device on which to load the agent
+        discount_factor (float): Discount factor for future rewards.
+        lr (float): Learning rate for the Adam optimizer.
+        eps (float): Stability parameters for the Adam optimizer.
+        clip_grad (float): The maximum magnitude of the gradient for any given parameter.
+            Set to 0 to disable.
+        entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
+        value_loss_scaling (float): Coefficient for the value function loss.
+        n_envs (int): Number of parallel environments.
+        n_steps (int): Length of each rollout.
+        feature_model_constructor (function): The function used to construct the neural feature model.
+        value_model_constructor (function): The function used to construct the neural value model.
+        policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
-        self.value_model = nature_value_head().to(device)
-        self.policy_model = nature_policy_head(env).to(device)
-        self.feature_model = nature_features().to(device)
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor']().to(device)
         self.hyperparameters = hyperparameters
         self.device = device
 

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -58,7 +58,7 @@ class C51AtariPreset(Preset):
         v_max (int): The expected return correspodning to the larget atom.
         model_constructor (function): The function used to construct the neural model.
     """
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         self.model = nature_c51(env, atoms=hyperparameters['atoms']).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -39,9 +39,9 @@ class C51AtariPreset(Preset):
     C51 Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The device
+        device (torch.device): the device on which to load the agent
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         minibatch_size (int): Number of experiences to sample in each training update.
@@ -49,14 +49,15 @@ class C51AtariPreset(Preset):
         target_update_frequency (int): Number of timesteps between updates the target network.
         replay_start_size (int): Number of experiences in replay buffer when training begins.
         replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
+        initial_exploration (float): Initial probability of choosing a random action,
             decayed over course of training.
-        final_exploration (int): Final probability of choosing a random action.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         atoms (int): The number of atoms in the categorical distribution used to represent
             the distributional value function.
         v_min (int): The expected return corresponding to the smallest atom.
         v_max (int): The expected return correspodning to the larget atom.
-        model_constructor (function): The function used to construct the neural model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -32,15 +32,19 @@ default_hyperparameters = {
     "atoms": 51,
     "v_min": -10,
     "v_max": 10,
+    # Model construction
+    "model_constructor": nature_c51
 }
 
 class C51AtariPreset(Preset):
     """
-    C51 Atari preset.
+    Categorical DQN (C51) Atari preset.
 
     Args:
-        env (all.environments.AtariEnvironment): The device
-        device (torch.device): the device on which to load the agent
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
@@ -58,10 +62,12 @@ class C51AtariPreset(Preset):
             the distributional value function.
         v_min (int): The expected return corresponding to the smallest atom.
         v_max (int): The expected return correspodning to the larget atom.
+        model_constructor (function): The function used to construct the neural model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
-        self.model = nature_c51(env, atoms=hyperparameters['atoms']).to(device)
+        self.model = hyperparameters['model_constructor'](env, atoms=hyperparameters['atoms']).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.approximation import QDist, FixedTarget
@@ -121,7 +122,7 @@ class C51AtariPreset(Preset):
 
     def test_agent(self):
         q_dist = QDist(
-            self.model,
+            copy.deepcopy(self.model),
             None,
             self.n_actions,
             self.hyperparameters['atoms'],

--- a/all/presets/atari/c51.py
+++ b/all/presets/atari/c51.py
@@ -37,6 +37,7 @@ default_hyperparameters = {
     "model_constructor": nature_c51
 }
 
+
 class C51AtariPreset(Preset):
     """
     Categorical DQN (C51) Atari preset.
@@ -65,6 +66,7 @@ class C51AtariPreset(Preset):
         v_max (int): The expected return correspodning to the larget atom.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
@@ -130,5 +132,6 @@ class C51AtariPreset(Preset):
             v_max=self.hyperparameters['v_max'],
         )
         return DeepmindAtariBody(C51TestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"]))
+
 
 c51 = preset_builder('c51', default_hyperparameters, C51AtariPreset)

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -38,6 +38,7 @@ default_hyperparameters = {
     "model_constructor": nature_ddqn
 }
 
+
 class DDQNAtariPreset(Preset):
     """
     Dueling Double DQN (DDQN) with Prioritized Experience Replay (PER) Atari Preset.
@@ -66,6 +67,7 @@ class DDQNAtariPreset(Preset):
             (0 = no correction, 1 = full correction)
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -123,9 +125,10 @@ class DDQNAtariPreset(Preset):
         )
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return DeepmindAtariBody(
             DDQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
+
 
 ddqn = preset_builder('ddqn', default_hyperparameters, DDQNAtariPreset)

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -34,16 +34,20 @@ default_hyperparameters = {
     "final_exploration": 0.01,
     "final_exploration_step": 250000,
     "test_exploration": 0.001,
+    # Model construction
+    "model_constructor": nature_ddqn
 }
 
 class DDQNAtariPreset(Preset):
     """
-    Dueling Double DQN with Prioritized Experience Replay (PER).
+    Dueling Double DQN (DDQN) with Prioritized Experience Replay (PER) Atari Preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         minibatch_size (int): Number of experiences to sample in each training update.
@@ -51,10 +55,11 @@ class DDQNAtariPreset(Preset):
         target_update_frequency (int): Number of timesteps between updates the target network.
         replay_start_size (int): Number of experiences in replay buffer when training begins.
         replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         alpha (float): Amount of prioritization in the prioritized experience replay buffer.
             (0 = no prioritization, 1 = full prioritization)
         beta (float): The strength of the importance sampling correction for prioritized experience replay.
@@ -63,7 +68,8 @@ class DDQNAtariPreset(Preset):
     """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
-        self.model = nature_ddqn(env).to(device)
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        self.model = hyperparameters['model_constructor'](env).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -61,7 +61,7 @@ class DDQNAtariPreset(Preset):
             (0 = no correction, 1 = full correction)
         model_constructor (function): The function used to construct the neural model.
     """
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         self.model = nature_ddqn(env).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -93,7 +93,7 @@ class DDQNAtariPreset(Preset):
                 self.hyperparameters['final_exploration'],
                 self.hyperparameters['replay_start_size'],
                 self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
-                name="epsilon",
+                name="exploration",
                 writer=writer
             )
         )

--- a/all/presets/atari/ddqn.py
+++ b/all/presets/atari/ddqn.py
@@ -1,7 +1,8 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.approximation import QNetwork, FixedTarget
-from all.agents import DDQN
+from all.agents import DDQN, DDQNTestAgent
 from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.memory import PrioritizedReplayBuffer
@@ -9,33 +10,33 @@ from all.nn import weighted_smooth_l1_loss
 from all.optim import LinearScheduler
 from all.policies import GreedyPolicy
 from .models import nature_ddqn
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ddqn(
-        # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        last_frame=40e6,
-        # Adam optimizer settings
-        lr=1e-4,
-        eps=1.5e-4,
-        # Training settings
-        minibatch_size=32,
-        update_frequency=4,
-        target_update_frequency=1000,
-        # Replay buffer settings
-        replay_start_size=80000,
-        replay_buffer_size=1000000,
-        # Explicit exploration
-        initial_exploration=1.,
-        final_exploration=0.01,
-        final_exploration_frame=4000000,
-        # Prioritized replay settings
-        alpha=0.5,
-        beta=0.5,
-        # Model construction
-        model_constructor=nature_ddqn
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-4,
+    "eps": 1.5e-4,
+    # Training settings
+    "minibatch_size": 32,
+    "update_frequency": 4,
+    "target_update_frequency": 1000,
+    # Replay buffer settings
+    "replay_start_size": 80000,
+    "replay_buffer_size": 1000000,
+    "alpha": 0.5,
+    "beta": 0.5,
+    # Explicit exploration
+    "initial_exploration": 1.,
+    "final_exploration": 0.01,
+    "final_exploration_step": 250000,
+    "test_exploration": 0.001,
+}
+
+class DDQNAtariPreset(Preset):
     """
     Dueling Double DQN with Prioritized Experience Replay (PER).
 
@@ -60,51 +61,65 @@ def ddqn(
             (0 = no correction, 1 = full correction)
         model_constructor (function): The function used to construct the neural model.
     """
-    def _ddqn(env, writer=DummyWriter()):
-        action_repeat = 4
-        last_timestep = last_frame / action_repeat
-        last_update = (last_timestep - replay_start_size) / update_frequency
-        final_exploration_step = final_exploration_frame / action_repeat
+    def __init__(self, hyperparameters, env, device='cuda'):
+        super().__init__()
+        self.model = nature_ddqn(env).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
 
-        model = model_constructor(env).to(device)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
+
         optimizer = Adam(
-            model.parameters(),
-            lr=lr,
-            eps=eps
+            self.model.parameters(),
+            lr=self.hyperparameters['lr'],
+            eps=self.hyperparameters['eps']
         )
+
         q = QNetwork(
-            model,
+            self.model,
             optimizer,
-            scheduler=CosineAnnealingLR(optimizer, last_update),
-            target=FixedTarget(target_update_frequency),
+            scheduler=CosineAnnealingLR(optimizer, n_updates),
+            target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer
         )
+
         policy = GreedyPolicy(
             q,
-            env.action_space.n,
+            self.n_actions,
             epsilon=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                replay_start_size,
-                final_exploration_step - replay_start_size,
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                self.hyperparameters['replay_start_size'],
+                self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
                 name="epsilon",
                 writer=writer
             )
         )
+
         replay_buffer = PrioritizedReplayBuffer(
-            replay_buffer_size,
-            alpha=alpha,
-            beta=beta,
-            device=device
+            self.hyperparameters['replay_buffer_size'],
+            alpha=self.hyperparameters['alpha'],
+            beta=self.hyperparameters['beta'],
+            device=self.device
         )
+
         return DeepmindAtariBody(
             DDQN(q, policy, replay_buffer,
                  loss=weighted_smooth_l1_loss,
-                 discount_factor=discount_factor,
-                 minibatch_size=minibatch_size,
-                 replay_start_size=replay_start_size,
-                 update_frequency=update_frequency,
+                 discount_factor=self.hyperparameters["discount_factor"],
+                 minibatch_size=self.hyperparameters["minibatch_size"],
+                 replay_start_size=self.hyperparameters["replay_start_size"],
+                 update_frequency=self.hyperparameters["update_frequency"],
                  ),
             lazy_frames=True
         )
-    return _ddqn
+
+    def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
+        return DeepmindAtariBody(
+            DDQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+        )
+
+ddqn = preset_builder('ddqn', default_hyperparameters, DDQNAtariPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -36,7 +36,7 @@ default_hyperparameters = {
     "final_exploration_step": 250000,
 }
 
-class DqnPreset(Preset):
+class DQNPreset(Preset):
     def __init__(self, hyperparameters, env, device='cuda'):
         super().__init__()
         self.model = nature_dqn(env)
@@ -99,4 +99,4 @@ class DqnPreset(Preset):
     def save(self, filename):
         return torch.save(self, filename)
 
-dqn = preset_builder('dqn', default_hyperparameters, DqnPreset)
+dqn = preset_builder('dqn', default_hyperparameters, DQNPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -29,7 +29,7 @@ class dqn(PresetBuilder):
         "target_update_frequency": 1000,
         # Replay buffer settings
         "replay_start_size": 80000,
-        "replay_buffer_size": 1000000,
+        "replay_buffer_size": 500000,
         # Explicit exploration
         "initial_exploration": 1.,
         "final_exploration": 0.01,

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -39,6 +39,7 @@ default_hyperparameters = {
     "model_constructor": nature_dqn
 }
 
+
 class DQNAtariPreset(Preset):
     """
     Deep Q-Network (DQN) Atari Preset.
@@ -63,6 +64,7 @@ class DQNAtariPreset(Preset):
         test_exploration (float): The exploration rate of the test Agent
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -121,9 +123,10 @@ class DQNAtariPreset(Preset):
         )
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return DeepmindAtariBody(
             DQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
+
 
 dqn = preset_builder('dqn', default_hyperparameters, DQNAtariPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -37,7 +37,7 @@ default_hyperparameters = {
     "test_exploration": 0.001,
 }
 
-class DQNPreset(Preset):
+class DQNAtariPreset(Preset):
     def __init__(self, hyperparameters, env, device='cuda'):
         super().__init__()
         self.model = nature_dqn(env).to(device)
@@ -98,4 +98,4 @@ class DQNPreset(Preset):
             DQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
 
-dqn = preset_builder('dqn', default_hyperparameters, DQNPreset)
+dqn = preset_builder('dqn', default_hyperparameters, DQNAtariPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -13,40 +13,35 @@ from all.memory import ExperienceReplayBuffer
 from all.optim import LinearScheduler
 from all.policies import GreedyPolicy
 from .models import nature_dqn
-from ..builder import PresetBuilder
+from ..builder import preset_builder
 from ..preset import Preset
 
-class dqn(PresetBuilder):
-    default_hyperparameters = {
-        # Common settings
-        "discount_factor": 0.99,
-        # Adam optimizer settings
-        "lr": 1e-4,
-        "eps": 1.5e-4,
-        # Training settings
-        "minibatch_size": 32,
-        "update_frequency": 4,
-        "target_update_frequency": 1000,
-        # Replay buffer settings
-        "replay_start_size": 80000,
-        "replay_buffer_size": 500000,
-        # Explicit exploration
-        "initial_exploration": 1.,
-        "final_exploration": 0.01,
-        "final_exploration_step": 250000,
-    }
 
-    def build(self):
-        model = nature_dqn(self._env).to(self._device)
-        return DqnPreset(model, self._hyperparameters, self._env.action_space.n, self._device)
-
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-4,
+    "eps": 1.5e-4,
+    # Training settings
+    "minibatch_size": 32,
+    "update_frequency": 4,
+    "target_update_frequency": 1000,
+    # Replay buffer settings
+    "replay_start_size": 80000,
+    "replay_buffer_size": 500000,
+    # Explicit exploration
+    "initial_exploration": 1.,
+    "final_exploration": 0.01,
+    "final_exploration_step": 250000,
+}
 
 class DqnPreset(Preset):
-    def __init__(self, model, hyperparameters, n_actions, device='cuda'):
+    def __init__(self, hyperparameters, env, device='cuda'):
         super().__init__()
-        self.model = model
+        self.model = nature_dqn(env)
         self.hyperparameters = hyperparameters
-        self.n_actions = n_actions
+        self.n_actions = env.action_space.n
         self.device = device
 
     def agent(self, writer=DummyWriter()):
@@ -104,3 +99,4 @@ class DqnPreset(Preset):
     def save(self, filename):
         return torch.save(self, filename)
 
+dqn = preset_builder('dqn', default_hyperparameters, DqnPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -38,7 +38,7 @@ default_hyperparameters = {
 }
 
 class DQNAtariPreset(Preset):
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         self.model = nature_dqn(env).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -28,8 +28,8 @@ default_hyperparameters = {
     "update_frequency": 4,
     "target_update_frequency": 1000,
     # Replay buffer settings
-    "replay_start_size": 80000,
-    "replay_buffer_size": 500000,
+    "replay_start_size": 10000,
+    "replay_buffer_size": 1000000,
     # Explicit exploration
     "initial_exploration": 1.,
     "final_exploration": 0.01,
@@ -45,7 +45,9 @@ class DQNAtariPreset(Preset):
         self.n_actions = env.action_space.n
         self.device = device
 
-    def agent(self, writer=DummyWriter()):
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
+
         optimizer = Adam(
             self.model.parameters(),
             lr=self.hyperparameters['lr'],
@@ -55,7 +57,7 @@ class DQNAtariPreset(Preset):
         q = QNetwork(
             self.model,
             optimizer,
-            # scheduler=CosineAnnealingLR(optimizer, last_update),
+            scheduler=CosineAnnealingLR(optimizer, n_updates),
             target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer
         )

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -35,12 +35,38 @@ default_hyperparameters = {
     "final_exploration": 0.01,
     "final_exploration_step": 250000,
     "test_exploration": 0.001,
+    # Model construction
+    "model_constructor": nature_dqn
 }
 
 class DQNAtariPreset(Preset):
+    """
+    Deep Q-Network (DQN) Atari Preset.
+
+    Args:
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
+        discount_factor (float, optional): Discount factor for future rewards.
+        lr (float): Learning rate for the Adam optimizer.
+        eps (float): Stability parameters for the Adam optimizer.
+        minibatch_size (int): Number of experiences to sample in each training update.
+        update_frequency (int): Number of timesteps per training update.
+        target_update_frequency (int): Number of timesteps between updates the target network.
+        replay_start_size (int): Number of experiences in replay buffer when training begins.
+        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
+        model_constructor (function): The function used to construct the neural model.
+    """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
-        self.model = nature_dqn(env).to(device)
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        self.model = hyperparameters['model_constructor'](env).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -1,96 +1,85 @@
+import copy
+import torch
+import numpy as np
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from torch.nn.functional import smooth_l1_loss
+from all import nn
 from all.approximation import QNetwork, FixedTarget
-from all.agents import DQN
+from all.agents import Agent, DQN, DQNTestAgent
 from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.memory import ExperienceReplayBuffer
 from all.optim import LinearScheduler
 from all.policies import GreedyPolicy
 from .models import nature_dqn
+from ..builder import PresetBuilder
+from ..preset import Preset
 
-
-def dqn(
+class dqn(PresetBuilder):
+    default_hyperparameters = {
         # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        last_frame=40e6,
+        "discount_factor": 0.99,
         # Adam optimizer settings
-        lr=1e-4,
-        eps=1.5e-4,
+        "lr": 1e-4,
+        "eps": 1.5e-4,
         # Training settings
-        minibatch_size=32,
-        update_frequency=4,
-        target_update_frequency=1000,
+        "minibatch_size": 32,
+        "update_frequency": 4,
+        "target_update_frequency": 1000,
         # Replay buffer settings
-        replay_start_size=80000,
-        replay_buffer_size=1000000,
+        "replay_start_size": 80000,
+        "replay_buffer_size": 1000000,
         # Explicit exploration
-        initial_exploration=1.,
-        final_exploration=0.01,
-        final_exploration_frame=4000000,
-        # Model construction
-        model_constructor=nature_dqn
-):
-    """
-    DQN Atari preset.
+        "initial_exploration": 1.,
+        "final_exploration": 0.01,
+        "final_exploration_step": 250000,
+    }
 
-    Args:
-        device (str): The device to load parameters and buffers onto for this agent.
-        discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
-        lr (float): Learning rate for the Adam optimizer.
-        eps (float): Stability parameters for the Adam optimizer.
-        minibatch_size (int): Number of experiences to sample in each training update.
-        update_frequency (int): Number of timesteps per training update.
-        target_update_frequency (int): Number of timesteps between updates the target network.
-        replay_start_size (int): Number of experiences in replay buffer when training begins.
-        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
-        model_constructor (function): The function used to construct the neural model.
-    """
-    def _dqn(env, writer=DummyWriter()):
-        action_repeat = 4
-        last_timestep = last_frame / action_repeat
-        last_update = (last_timestep - replay_start_size) / update_frequency
-        final_exploration_step = final_exploration_frame / action_repeat
+    def build(self):
+        model = nature_dqn(self._env).to(self._device)
+        return DqnPreset(model, self._hyperparameters, self._env.action_space.n, self._device)
 
-        model = model_constructor(env).to(device)
 
+class DqnPreset(Preset):
+    def __init__(self, model, hyperparameters, n_actions, device='cuda'):
+        super().__init__()
+        self.model = model
+        self.hyperparameters = hyperparameters
+        self.n_actions = n_actions
+        self.device = device
+
+    def agent(self, writer=DummyWriter()):
         optimizer = Adam(
-            model.parameters(),
-            lr=lr,
-            eps=eps
+            self.model.parameters(),
+            lr=self.hyperparameters['lr'],
+            eps=self.hyperparameters['eps']
         )
 
         q = QNetwork(
-            model,
+            self.model,
             optimizer,
-            scheduler=CosineAnnealingLR(optimizer, last_update),
-            target=FixedTarget(target_update_frequency),
+            # scheduler=CosineAnnealingLR(optimizer, last_update),
+            target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer
         )
 
         policy = GreedyPolicy(
             q,
-            env.action_space.n,
+            self.n_actions,
             epsilon=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                replay_start_size,
-                final_exploration_step - replay_start_size,
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                self.hyperparameters['replay_start_size'],
+                self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
                 name="epsilon",
                 writer=writer
             )
         )
 
         replay_buffer = ExperienceReplayBuffer(
-            replay_buffer_size,
-            device=device
+            self.hyperparameters['replay_buffer_size'],
+            device=self.device
         )
 
         return DeepmindAtariBody(
@@ -98,12 +87,20 @@ def dqn(
                 q,
                 policy,
                 replay_buffer,
-                discount_factor=discount_factor,
+                discount_factor=self.hyperparameters['discount_factor'],
                 loss=smooth_l1_loss,
-                minibatch_size=minibatch_size,
-                replay_start_size=replay_start_size,
-                update_frequency=update_frequency,
+                minibatch_size=self.hyperparameters['minibatch_size'],
+                replay_start_size=self.hyperparameters['replay_start_size'],
+                update_frequency=self.hyperparameters['update_frequency'],
             ),
             lazy_frames=True
         )
-    return _dqn
+
+    def test_agent(self):
+        return DeepmindAtariBody(
+            DQNTestAgent(copy.deepcopy(self.model), self.n_actions, exploration=0.001)
+        )
+
+    def save(self, filename):
+        return torch.save(self, filename)
+

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -34,12 +34,13 @@ default_hyperparameters = {
     "initial_exploration": 1.,
     "final_exploration": 0.01,
     "final_exploration_step": 250000,
+    "test_exploration": 0.001,
 }
 
 class DQNPreset(Preset):
     def __init__(self, hyperparameters, env, device='cuda'):
         super().__init__()
-        self.model = nature_dqn(env)
+        self.model = nature_dqn(env).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device
@@ -92,11 +93,9 @@ class DQNPreset(Preset):
         )
 
     def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
         return DeepmindAtariBody(
-            DQNTestAgent(copy.deepcopy(self.model), self.n_actions, exploration=0.001)
+            DQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
-
-    def save(self, filename):
-        return torch.save(self, filename)
 
 dqn = preset_builder('dqn', default_hyperparameters, DQNPreset)

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -70,7 +70,7 @@ class DQNAtariPreset(Preset):
                 self.hyperparameters['final_exploration'],
                 self.hyperparameters['replay_start_size'],
                 self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
-                name="epsilon",
+                name="exploration",
                 writer=writer
             )
         )

--- a/all/presets/atari/dqn.py
+++ b/all/presets/atari/dqn.py
@@ -28,7 +28,7 @@ default_hyperparameters = {
     "update_frequency": 4,
     "target_update_frequency": 1000,
     # Replay buffer settings
-    "replay_start_size": 10000,
+    "replay_start_size": 80000,
     "replay_buffer_size": 1000000,
     # Explicit exploration
     "initial_exploration": 1.,

--- a/all/presets/atari/ppo.py
+++ b/all/presets/atari/ppo.py
@@ -31,16 +31,22 @@ default_hyperparameters = {
     "n_steps": 128,
     # GAE settings
     "lam": 0.95,
+    # Model construction
+    "feature_model_constructor": nature_features,
+    "value_model_constructor": nature_value_head,
+    "policy_model_constructor": nature_policy_head
 }
 
 class PPOAtariPreset(Preset):
     """
-    PPO Atari preset.
+    Proximal Policy Optimization (PPO) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         clip_grad (float): The maximum magnitude of the gradient for any given parameter.
@@ -59,10 +65,11 @@ class PPOAtariPreset(Preset):
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
-        self.value_model = nature_value_head().to(device)
-        self.policy_model = nature_policy_head(env).to(device)
-        self.feature_model = nature_features().to(device)
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor']().to(device)
         self.hyperparameters = hyperparameters
         self.device = device
 

--- a/all/presets/atari/ppo.py
+++ b/all/presets/atari/ppo.py
@@ -37,6 +37,7 @@ default_hyperparameters = {
     "policy_model_constructor": nature_policy_head
 }
 
+
 class PPOAtariPreset(Preset):
     """
     Proximal Policy Optimization (PPO) Atari preset.
@@ -64,6 +65,7 @@ class PPOAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -133,5 +135,6 @@ class PPOAtariPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return DeepmindAtariBody(PPOTestAgent(features, policy))
+
 
 ppo = preset_builder('ppo', default_hyperparameters, PPOAtariPreset)

--- a/all/presets/atari/ppo.py
+++ b/all/presets/atari/ppo.py
@@ -58,7 +58,7 @@ class PPOAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def __init__(self, hyperparameters, env, device):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.value_model = nature_value_head().to(device)
         self.policy_model = nature_policy_head(env).to(device)

--- a/all/presets/atari/ppo.py
+++ b/all/presets/atari/ppo.py
@@ -1,40 +1,39 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
-from all.agents import PPO
+from all.agents import PPO, PPOTestAgent
 from all.bodies import DeepmindAtariBody
 from all.approximation import VNetwork, FeatureNetwork
 from all.logging import DummyWriter
 from all.optim import LinearScheduler
 from all.policies import SoftmaxPolicy
 from .models import nature_features, nature_value_head, nature_policy_head
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ppo(
-        # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        last_frame=40e6,
-        # Adam optimizer settings
-        lr=2.5e-4,  # Adam learning rate
-        eps=1e-5,  # Adam stability
-        # Other optimization settings
-        clip_grad=0.5,
-        entropy_loss_scaling=0.01,
-        value_loss_scaling=0.5,
-        clip_initial=0.1,
-        clip_final=0.01,
-        # Batch settings
-        epochs=4,
-        minibatches=4,
-        n_envs=8,
-        n_steps=128,
-        # GAE settings
-        lam=0.95,
-        # Model construction
-        feature_model_constructor=nature_features,
-        value_model_constructor=nature_value_head,
-        policy_model_constructor=nature_policy_head
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 2.5e-4,
+    "eps": 1e-5,
+    # Other optimization settings
+    "clip_grad": 0.5,
+    "entropy_loss_scaling": 0.01,
+    "value_loss_scaling": 0.5,
+    "clip_initial": 0.1,
+    "clip_final": 0.01,
+    # Batch settings
+    "epochs": 4,
+    "minibatches": 4,
+    "n_envs": 8,
+    "n_steps": 128,
+    # GAE settings
+    "lam": 0.95,
+}
+
+class PPOAtariPreset(Preset):
     """
     PPO Atari preset.
 
@@ -59,54 +58,44 @@ def ppo(
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _ppo(envs, writer=DummyWriter()):
-        env = envs[0]
+    def __init__(self, hyperparameters, env, device):
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.value_model = nature_value_head().to(device)
+        self.policy_model = nature_policy_head(env).to(device)
+        self.feature_model = nature_features().to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
 
-        # Update epoch * minibatches times per update,
-        # but we only update once per n_steps,
-        # with n_envs and 4 frames per step
-        final_anneal_step = last_frame * epochs * minibatches / (n_steps * n_envs * 4)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps * self.hyperparameters['epochs'] * self.hyperparameters['minibatches'] / (self.hyperparameters['n_steps'] * self.hyperparameters['n_envs'])
 
-        value_model = value_model_constructor().to(device)
-        policy_model = policy_model_constructor(env).to(device)
-        feature_model = feature_model_constructor().to(device)
-
-        feature_optimizer = Adam(
-            feature_model.parameters(), lr=lr, eps=eps
-        )
-        value_optimizer = Adam(value_model.parameters(), lr=lr, eps=eps)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr, eps=eps)
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
 
         features = FeatureNetwork(
-            feature_model,
+            self.feature_model,
             feature_optimizer,
-            clip_grad=clip_grad,
-            scheduler=CosineAnnealingLR(
-                feature_optimizer,
-                final_anneal_step
-            ),
+            scheduler=CosineAnnealingLR(feature_optimizer, n_updates),
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         v = VNetwork(
-            value_model,
+            self.value_model,
             value_optimizer,
-            loss_scaling=value_loss_scaling,
-            clip_grad=clip_grad,
-            writer=writer,
-            scheduler=CosineAnnealingLR(
-                value_optimizer,
-                final_anneal_step
-            ),
+            scheduler=CosineAnnealingLR(value_optimizer, n_updates),
+            loss_scaling=self.hyperparameters["value_loss_scaling"],
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
         )
+
         policy = SoftmaxPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
-            clip_grad=clip_grad,
-            writer=writer,
-            scheduler=CosineAnnealingLR(
-                policy_optimizer,
-                final_anneal_step
-            ),
+            scheduler=CosineAnnealingLR(policy_optimizer, n_updates),
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
         )
 
         return DeepmindAtariBody(
@@ -115,25 +104,27 @@ def ppo(
                 v,
                 policy,
                 epsilon=LinearScheduler(
-                    clip_initial,
-                    clip_final,
+                    self.hyperparameters["clip_initial"],
+                    self.hyperparameters["clip_final"],
                     0,
-                    final_anneal_step,
+                    n_updates,
                     name='clip',
                     writer=writer
                 ),
-                epochs=epochs,
-                minibatches=minibatches,
-                n_envs=n_envs,
-                n_steps=n_steps,
-                discount_factor=discount_factor,
-                lam=lam,
-                entropy_loss_scaling=entropy_loss_scaling,
+                epochs=self.hyperparameters["epochs"],
+                minibatches=self.hyperparameters["minibatches"],
+                n_envs=self.hyperparameters["n_envs"],
+                n_steps=self.hyperparameters["n_steps"],
+                discount_factor=self.hyperparameters["discount_factor"],
+                lam=self.hyperparameters["lam"],
+                entropy_loss_scaling=self.hyperparameters["entropy_loss_scaling"],
                 writer=writer,
             )
         )
 
-    return _ppo, n_envs
+    def test_agent(self):
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
+        return DeepmindAtariBody(PPOTestAgent(features, policy))
 
-
-__all__ = ["ppo"]
+ppo = preset_builder('ppo', default_hyperparameters, PPOAtariPreset)

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -1,118 +1,116 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.approximation import QDist, FixedTarget
-from all.agents import Rainbow
+from all.agents import Rainbow, RainbowTestAgent
 from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.memory import PrioritizedReplayBuffer, NStepReplayBuffer
 from all.optim import LinearScheduler
 from .models import nature_rainbow
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def rainbow(
-        # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        last_frame=40e6,
-        # Adam optimizer settings
-        lr=1e-4,
-        eps=1.5e-4,
-        # Training settings
-        minibatch_size=32,
-        update_frequency=4,
-        target_update_frequency=1000,
-        # Replay buffer settings
-        replay_start_size=80000,
-        replay_buffer_size=1000000,
-        # Explicit exploration
-        initial_exploration=0.02,
-        final_exploration=0.,
-        # Prioritized replay settings
-        alpha=0.5,
-        beta=0.5,
-        # Multi-step learning
-        n_steps=3,
-        # Distributional RL
-        atoms=51,
-        v_min=-10,
-        v_max=10,
-        # Noisy Nets
-        sigma=0.5,
-        # Model construction
-        model_constructor=nature_rainbow
-):
-    """
-    Rainbow Atari Preset.
+default_hyperparameters = {
+    "discount_factor": 0.99,
+    "lr": 1e-4,
+    "eps": 1.5e-4,
+    # Training settings
+    "minibatch_size": 32,
+    "update_frequency": 4,
+    "target_update_frequency": 1000,
+    # Replay buffer settings
+    "replay_start_size": 80000,
+    "replay_buffer_size": 1000000,
+    # Explicit exploration
+    "initial_exploration": 0.02,
+    "final_exploration": 0.,
+    "test_exploration": 0.001,
+    # Prioritized replay settings
+    "alpha": 0.5,
+    "beta": 0.5,
+    # Multi-step learning
+    "n_steps": 3,
+    # Distributional RL
+    "atoms": 51,
+    "v_min": -10,
+    "v_max": 10,
+    # Noisy Nets
+    "sigma": 0.5,
+}
 
-    Args:
-        device (str): The device to load parameters and buffers onto for this agent.
-        discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
-        lr (float): Learning rate for the Adam optimizer.
-        eps (float): Stability parameters for the Adam optimizer.
-        minibatch_size (int): Number of experiences to sample in each training update.
-        update_frequency (int): Number of timesteps per training update.
-        target_update_frequency (int): Number of timesteps between updates the target network.
-        replay_start_size (int): Number of experiences in replay buffer when training begins.
-        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed over course of training.
-        final_exploration (int): Final probability of choosing a random action.
-        alpha (float): Amount of prioritization in the prioritized experience replay buffer.
-            (0 = no prioritization, 1 = full prioritization)
-        beta (float): The strength of the importance sampling correction for prioritized experience replay.
-            (0 = no correction, 1 = full correction)
-        n_steps (int): The number of steps for n-step Q-learning.
-        atoms (int): The number of atoms in the categorical distribution used to represent
-            the distributional value function.
-        v_min (int): The expected return corresponding to the smallest atom.
-        v_max (int): The expected return correspodning to the larget atom.
-        sigma (float): Initial noisy network noise.
-        model_constructor (function): The function used to construct the neural model.
-    """
-    def _rainbow(env, writer=DummyWriter()):
-        action_repeat = 4
-        last_timestep = last_frame / action_repeat
-        last_update = (last_timestep - replay_start_size) / update_frequency
+class RainbowAtariPreset(Preset):
+    def __init__(self, hyperparameters, env, device='cuda'):
+        super().__init__()
+        self.model = nature_rainbow(env, atoms=hyperparameters["atoms"], sigma=hyperparameters["sigma"]).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
 
-        model = model_constructor(env, atoms=atoms, sigma=sigma).to(device)
-        optimizer = Adam(model.parameters(), lr=lr, eps=eps)
-        q = QDist(
-            model,
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
+
+        optimizer = Adam(
+            self.model.parameters(),
+            lr=self.hyperparameters['lr'],
+            eps=self.hyperparameters['eps']
+        )
+
+        q_dist = QDist(
+            self.model,
             optimizer,
-            env.action_space.n,
-            atoms,
-            scheduler=CosineAnnealingLR(optimizer, last_update),
-            v_min=v_min,
-            v_max=v_max,
-            target=FixedTarget(target_update_frequency),
+            self.n_actions,
+            self.hyperparameters['atoms'],
+            scheduler=CosineAnnealingLR(optimizer, n_updates),
+            v_min=self.hyperparameters['v_min'],
+            v_max=self.hyperparameters['v_max'],
+            target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer,
         )
-        replay_buffer = PrioritizedReplayBuffer(
-            replay_buffer_size,
-            alpha=alpha,
-            beta=beta,
-            device=device
-        )
-        replay_buffer = NStepReplayBuffer(n_steps, discount_factor, replay_buffer)
 
-        agent = Rainbow(
-            q,
-            replay_buffer,
-            exploration=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                0,
-                last_timestep,
-                name='exploration',
-                writer=writer
+        replay_buffer = NStepReplayBuffer(
+            self.hyperparameters['n_steps'],
+            self.hyperparameters['discount_factor'],
+            PrioritizedReplayBuffer(
+                self.hyperparameters['replay_buffer_size'],
+                alpha=self.hyperparameters['alpha'],
+                beta=self.hyperparameters['beta'],
+                device=self.device
+            )
+        )
+
+        return DeepmindAtariBody(
+            Rainbow(
+                q_dist,
+                replay_buffer,
+                exploration=LinearScheduler(
+                    self.hyperparameters['initial_exploration'],
+                    self.hyperparameters['final_exploration'],
+                    0,
+                    train_steps - self.hyperparameters['replay_start_size'],
+                    name="epsilon",
+                    writer=writer
+                ),
+                discount_factor=self.hyperparameters['discount_factor'] ** self.hyperparameters["n_steps"],
+                minibatch_size=self.hyperparameters['minibatch_size'],
+                replay_start_size=self.hyperparameters['replay_start_size'],
+                update_frequency=self.hyperparameters['update_frequency'],
+                writer=writer,
             ),
-            discount_factor=discount_factor ** n_steps,
-            minibatch_size=minibatch_size,
-            replay_start_size=replay_start_size,
-            update_frequency=update_frequency,
-            writer=writer,
+            lazy_frames=True,
+            episodic_lives=True
         )
-        return DeepmindAtariBody(agent, lazy_frames=True, episodic_lives=True)
 
-    return _rainbow
+    def test_agent(self):
+        q_dist = QDist(
+            self.model,
+            None,
+            self.n_actions,
+            self.hyperparameters['atoms'],
+            v_min=self.hyperparameters['v_min'],
+            v_max=self.hyperparameters['v_max'],
+        )
+        return DeepmindAtariBody(RainbowTestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"]))
+
+rainbow = preset_builder('rainbow', default_hyperparameters, RainbowAtariPreset)

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -42,6 +42,7 @@ default_hyperparameters = {
     "model_constructor": nature_rainbow
 }
 
+
 class RainbowAtariPreset(Preset):
     """
     Rainbow DQN Atari Preset.
@@ -74,6 +75,7 @@ class RainbowAtariPreset(Preset):
         sigma (float): Initial noisy network noise.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -146,5 +148,6 @@ class RainbowAtariPreset(Preset):
             v_max=self.hyperparameters['v_max'],
         )
         return DeepmindAtariBody(RainbowTestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"]))
+
 
 rainbow = preset_builder('rainbow', default_hyperparameters, RainbowAtariPreset)

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -138,7 +138,7 @@ class RainbowAtariPreset(Preset):
 
     def test_agent(self):
         q_dist = QDist(
-            self.model,
+            copy.deepcopy(self.model),
             None,
             self.n_actions,
             self.hyperparameters['atoms'],

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -38,12 +38,46 @@ default_hyperparameters = {
     "v_max": 10,
     # Noisy Nets
     "sigma": 0.5,
+    # Model construction
+    "model_constructor": nature_rainbow
 }
 
 class RainbowAtariPreset(Preset):
+    """
+    Rainbow DQN Atari Preset.
+
+    Args:
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
+        discount_factor (float): Discount factor for future rewards.
+        lr (float): Learning rate for the Adam optimizer.
+        eps (float): Stability parameters for the Adam optimizer.
+        minibatch_size (int): Number of experiences to sample in each training update.
+        update_frequency (int): Number of timesteps per training update.
+        target_update_frequency (int): Number of timesteps between updates the target network.
+        replay_start_size (int): Number of experiences in replay buffer when training begins.
+        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        alpha (float): Amount of prioritization in the prioritized experience replay buffer.
+            (0 = no prioritization, 1 = full prioritization)
+        beta (float): The strength of the importance sampling correction for prioritized experience replay.
+            (0 = no correction, 1 = full correction)
+        n_steps (int): The number of steps for n-step Q-learning.
+        atoms (int): The number of atoms in the categorical distribution used to represent
+            the distributional value function.
+        v_min (int): The expected return corresponding to the smallest atom.
+        v_max (int): The expected return correspodning to the larget atom.
+        sigma (float): Initial noisy network noise.
+        model_constructor (function): The function used to construct the neural model.
+    """
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
-        self.model = nature_rainbow(env, atoms=hyperparameters["atoms"], sigma=hyperparameters["sigma"]).to(device)
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        self.model = hyperparameters['model_constructor'](env, atoms=hyperparameters["atoms"], sigma=hyperparameters["sigma"]).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -89,7 +89,7 @@ class RainbowAtariPreset(Preset):
                     self.hyperparameters['final_exploration'],
                     0,
                     train_steps - self.hyperparameters['replay_start_size'],
-                    name="epsilon",
+                    name="exploration",
                     writer=writer
                 ),
                 discount_factor=self.hyperparameters['discount_factor'] ** self.hyperparameters["n_steps"],

--- a/all/presets/atari/rainbow.py
+++ b/all/presets/atari/rainbow.py
@@ -41,7 +41,7 @@ default_hyperparameters = {
 }
 
 class RainbowAtariPreset(Preset):
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         self.model = nature_rainbow(env, atoms=hyperparameters["atoms"], sigma=hyperparameters["sigma"]).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/vac.py
+++ b/all/presets/atari/vac.py
@@ -43,7 +43,7 @@ class VACAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def __init__(self, hyperparameters, env, device):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.value_model = nature_value_head().to(device)
         self.policy_model = nature_policy_head(env).to(device)

--- a/all/presets/atari/vac.py
+++ b/all/presets/atari/vac.py
@@ -28,6 +28,7 @@ default_hyperparameters = {
     "policy_model_constructor": nature_policy_head
 }
 
+
 class VACAtariPreset(Preset):
     """
     Vanilla Actor-Critic (VAC) Atari preset.
@@ -49,6 +50,7 @@ class VACAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -98,5 +100,6 @@ class VACAtariPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return DeepmindAtariBody(VACTestAgent(features, policy))
+
 
 vac = preset_builder('vac', default_hyperparameters, VACAtariPreset)

--- a/all/presets/atari/vac.py
+++ b/all/presets/atari/vac.py
@@ -22,16 +22,22 @@ default_hyperparameters = {
     "value_loss_scaling": 0.25,
     # Parallel actors
     "n_envs": 16,
+    # Model construction
+    "feature_model_constructor": nature_features,
+    "value_model_constructor": nature_value_head,
+    "policy_model_constructor": nature_policy_head
 }
 
 class VACAtariPreset(Preset):
     """
-    Vanilla Actor-Critic Atari preset.
+    Vanilla Actor-Critic (VAC) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr_v (float): Learning rate for value network.
         lr_pi (float): Learning rate for policy network and feature network.
         eps (float): Stability parameters for the Adam optimizer.
@@ -44,10 +50,11 @@ class VACAtariPreset(Preset):
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
-        self.value_model = nature_value_head().to(device)
-        self.policy_model = nature_policy_head(env).to(device)
-        self.feature_model = nature_features().to(device)
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor']().to(device)
         self.hyperparameters = hyperparameters
         self.device = device
 

--- a/all/presets/atari/vpg.py
+++ b/all/presets/atari/vpg.py
@@ -22,16 +22,22 @@ default_hyperparameters = {
     "clip_grad": 0.5,
     "value_loss_scaling": 0.25,
     "min_batch_size": 1000,
+    # Model construction
+    "feature_model_constructor": nature_features,
+    "value_model_constructor": nature_value_head,
+    "policy_model_constructor": nature_policy_head
 }
 
 class VPGAtariPreset(Preset):
     """
-    Vanilla Policy Gradient Atari preset.
+    Vanilla Policy Gradient (VPG) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         clip_grad (float): The maximum magnitude of the gradient for any given parameter.
@@ -44,10 +50,11 @@ class VPGAtariPreset(Preset):
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
-        self.value_model = nature_value_head().to(device)
-        self.policy_model = nature_policy_head(env).to(device)
-        self.feature_model = nature_features().to(device)
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor']().to(device)
         self.hyperparameters = hyperparameters
         self.device = device
 

--- a/all/presets/atari/vpg.py
+++ b/all/presets/atari/vpg.py
@@ -28,6 +28,7 @@ default_hyperparameters = {
     "policy_model_constructor": nature_policy_head
 }
 
+
 class VPGAtariPreset(Preset):
     """
     Vanilla Policy Gradient (VPG) Atari preset.
@@ -49,6 +50,7 @@ class VPGAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
@@ -98,5 +100,6 @@ class VPGAtariPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return DeepmindAtariBody(VPGTestAgent(features, policy))
+
 
 vpg = preset_builder('vpg', default_hyperparameters, VPGAtariPreset)

--- a/all/presets/atari/vpg.py
+++ b/all/presets/atari/vpg.py
@@ -43,7 +43,7 @@ class VPGAtariPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def __init__(self, hyperparameters, env, device):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         self.value_model = nature_value_head().to(device)
         self.policy_model = nature_policy_head(env).to(device)

--- a/all/presets/atari/vqn.py
+++ b/all/presets/atari/vqn.py
@@ -50,6 +50,7 @@ class VQNAtariPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -92,9 +93,10 @@ class VQNAtariPreset(Preset):
         )
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return DeepmindAtariBody(
             VQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
+
 
 vqn = preset_builder('vqn', default_hyperparameters, VQNAtariPreset)

--- a/all/presets/atari/vqn.py
+++ b/all/presets/atari/vqn.py
@@ -25,28 +25,35 @@ default_hyperparameters = {
     "test_exploration": 0.001,
     # Parallel actors
     "n_envs": 64,
+    # Model construction
+    "model_constructor": nature_ddqn
 }
 
 
 class VQNAtariPreset(Preset):
     """
-    Vanilla Q-Network Atari preset.
+    Vanilla Q-Network (VQN) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
-        self.model = nature_ddqn(env).to(device)
+        self.model = hyperparameters['model_constructor'](env).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari/vqn.py
+++ b/all/presets/atari/vqn.py
@@ -44,7 +44,7 @@ class VQNAtariPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.model = nature_ddqn(env).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/vqn.py
+++ b/all/presets/atari/vqn.py
@@ -1,29 +1,34 @@
+import copy
 from torch.optim import Adam
+from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.approximation import QNetwork
-from all.agents import VQN
+from all.agents import VQN, VQNTestAgent
 from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.optim import LinearScheduler
 from all.policies import ParallelGreedyPolicy
 from .models import nature_ddqn
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def vqn(
-        # Common settings
-        device="cuda",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-3,
-        eps=1.5e-4,
-        # Exploration settings
-        initial_exploration=1.,
-        final_exploration=0.02,
-        final_exploration_frame=1000000,
-        # Parallel actors
-        n_envs=64,
-        # Model construction
-        model_constructor=nature_ddqn
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-3,
+    "eps": 1.5e-4,
+    # Explicit exploration
+    "initial_exploration": 1.,
+    "final_exploration": 0.01,
+    "final_exploration_step": 250000,
+    "test_exploration": 0.001,
+    # Parallel actors
+    "n_envs": 64,
+}
+
+
+class VQNAtariPreset(Preset):
     """
     Vanilla Q-Network Atari preset.
 
@@ -39,31 +44,50 @@ def vqn(
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
-    def _vqn(envs, writer=DummyWriter()):
-        action_repeat = 4
-        final_exploration_timestep = final_exploration_frame / action_repeat
+    def __init__(self, hyperparameters, env, device='cuda'):
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.model = nature_ddqn(env).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
 
-        env = envs[0]
-        model = model_constructor(env).to(device)
-        optimizer = Adam(model.parameters(), lr=lr, eps=eps)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps / self.hyperparameters['n_envs']
+
+        optimizer = Adam(
+            self.model.parameters(),
+            lr=self.hyperparameters['lr'],
+            eps=self.hyperparameters['eps']
+        )
+
         q = QNetwork(
-            model,
+            self.model,
             optimizer,
+            scheduler=CosineAnnealingLR(optimizer, n_updates),
             writer=writer
         )
+
         policy = ParallelGreedyPolicy(
             q,
-            env.action_space.n,
+            self.n_actions,
             epsilon=LinearScheduler(
-                initial_exploration,
-                final_exploration,
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
                 0,
-                final_exploration_timestep,
-                name="epsilon",
+                self.hyperparameters["final_exploration_step"] / self.hyperparameters["n_envs"],
+                name="exploration",
                 writer=writer
             )
         )
+
         return DeepmindAtariBody(
-            VQN(q, policy, discount_factor=discount_factor),
+            VQN(q, policy, discount_factor=self.hyperparameters['discount_factor']),
         )
-    return _vqn, n_envs
+
+    def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
+        return DeepmindAtariBody(
+            VQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+        )
+
+vqn = preset_builder('vqn', default_hyperparameters, VQNAtariPreset)

--- a/all/presets/atari/vsarsa.py
+++ b/all/presets/atari/vsarsa.py
@@ -44,7 +44,7 @@ class VSarsaAtariPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
-    def __init__(self, hyperparameters, env, device='cuda'):
+    def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__(n_envs=hyperparameters['n_envs'])
         self.model = nature_ddqn(env).to(device)
         self.hyperparameters = hyperparameters

--- a/all/presets/atari/vsarsa.py
+++ b/all/presets/atari/vsarsa.py
@@ -50,6 +50,7 @@ class VSarsaAtariPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -92,9 +93,10 @@ class VSarsaAtariPreset(Preset):
         )
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return DeepmindAtariBody(
             VSarsaTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
         )
+
 
 vsarsa = preset_builder('vsarsa', default_hyperparameters, VSarsaAtariPreset)

--- a/all/presets/atari/vsarsa.py
+++ b/all/presets/atari/vsarsa.py
@@ -25,28 +25,35 @@ default_hyperparameters = {
     "test_exploration": 0.001,
     # Parallel actors
     "n_envs": 64,
+    # Model construction
+    "model_constructor": nature_ddqn
 }
 
 
 class VSarsaAtariPreset(Preset):
     """
-    Vanilla SARSA Atari preset.
+    Vanilla SARSA (VSarsa) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
-        self.model = nature_ddqn(env).to(device)
+        self.model = hyperparameters['model_constructor'](env).to(device)
         self.hyperparameters = hyperparameters
         self.n_actions = env.action_space.n
         self.device = device

--- a/all/presets/atari_test.py
+++ b/all/presets/atari_test.py
@@ -1,0 +1,74 @@
+import os
+import unittest
+import torch
+from all.environments import AtariEnvironment
+from all.presets.atari import (
+    a2c,
+    c51,
+    ddqn,
+    dqn,
+    ppo,
+    rainbow,
+    vac,
+    vpg,
+    vsarsa,
+    vqn
+)
+
+
+class TestAtariPresets(unittest.TestCase):
+    def setUp(self):
+        self.env = AtariEnvironment('Breakout')
+        self.env.reset()
+
+    def tearDown(self):
+        if os.path.exists('test_preset.pt'):
+            os.remove('test_preset.pt')
+
+    def test_a2c(self):
+        self.validate_preset(a2c)
+
+    def test_c51(self):
+        self.validate_preset(c51)
+
+    def test_ddqn(self):
+        self.validate_preset(ddqn)
+
+    def test_dqn(self):
+        self.validate_preset(dqn)
+
+    def test_ppo(self):
+        self.validate_preset(ppo)
+
+    def test_rainbow(self):
+        self.validate_preset(rainbow)
+
+    def test_vac(self):
+        self.validate_preset(vac)
+
+    def test_vpq(self):
+        self.validate_preset(vpg)
+
+    def test_vsarsa(self):
+        self.validate_preset(vsarsa)
+
+    def test_vqn(self):
+        self.validate_preset(vqn)
+
+    def validate_preset(self, builder):
+        preset = builder().device('cpu').env(self.env).build()
+        # normal agent
+        agent = preset.agent()
+        agent.act(self.env.state)
+        # test agent
+        test_agent = preset.test_agent()
+        test_agent.act(self.env.state)
+        # test save/load
+        preset.save('test_preset.pt')
+        preset = torch.load('test_preset.pt')
+        test_agent = preset.test_agent()
+        test_agent.act(self.env.state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/all/presets/atari_test.py
+++ b/all/presets/atari_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import torch
 from all.environments import AtariEnvironment
+from all.logging import DummyWriter
 from all.presets.atari import (
     a2c,
     c51,
@@ -58,7 +59,7 @@ class TestAtariPresets(unittest.TestCase):
     def validate_preset(self, builder):
         preset = builder().device('cpu').env(self.env).build()
         # normal agent
-        agent = preset.agent()
+        agent = preset.agent(writer=DummyWriter(), train_steps=100000)
         agent.act(self.env.state)
         # test agent
         test_agent = preset.test_agent()

--- a/all/presets/builder.py
+++ b/all/presets/builder.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+
 def preset_builder(default_name, default_hyperparameters, constructor):
     class PresetBuilder():
         def __init__(self, name=default_name, hyperparameters=default_hyperparameters, env=None, device='cuda'):

--- a/all/presets/builder.py
+++ b/all/presets/builder.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+
+class PresetBuilder(ABC):
+    default_hyperparameters = None
+
+    def __init__(self, hyperparameters={}, env=None, device='cuda'):
+        if self.default_hyperparameters is None:
+            raise AttributeError('default_hyperparameters must be defined')
+        self._device = device
+        self._env = env
+        self._hyperparameters = {**self.default_hyperparameters, **hyperparameters}
+
+    def hyperparameters(self, **hyperparameters):
+        self._validate_hyperparameters(hyperparameters)
+        return self.__class__(
+            device=self._device,
+            hyperparameters={**self.default_hyperparameters, **hyperparameters},
+            env=self._env
+        )
+
+    def env(self, env):
+        return self.__class__(
+            device=self._device,
+            hyperparameters=self._hyperparameters,
+            env=env
+        )
+
+    def device(self, device):
+        return self.__class__(device=device, hyperparameters=self._hyperparameters, env=self._env)
+
+    def _validate_hyperparameters(self, hyperparameters):
+        for key in hyperparameters.keys():
+            if key not in self.default_hyperparameters:
+                raise KeyError("Invalid hyperparameter: {}".format(key))
+
+    @abstractmethod
+    def build(self):
+        pass

--- a/all/presets/builder.py
+++ b/all/presets/builder.py
@@ -14,7 +14,7 @@ def preset_builder(default_name, default_hyperparameters, constructor):
 
         def name(self, name):
             return self.__class__(
-                name=_name,
+                name=name,
                 device=self._device,
                 hyperparameters=self._hyperparameters,
                 env=self._env

--- a/all/presets/builder.py
+++ b/all/presets/builder.py
@@ -44,6 +44,6 @@ def preset_builder(default_name, default_hyperparameters, constructor):
                     raise KeyError("Invalid hyperparameter: {}".format(key))
 
         def build(self):
-            return constructor(self._hyperparameters, self._env, self._device)
+            return constructor(self._env, device=self._device, **self._hyperparameters)
 
     return PresetBuilder

--- a/all/presets/builder.py
+++ b/all/presets/builder.py
@@ -1,39 +1,49 @@
 from abc import ABC, abstractmethod
 
+def preset_builder(default_name, default_hyperparameters, constructor):
+    class PresetBuilder():
+        def __init__(self, name=default_name, hyperparameters=default_hyperparameters, env=None, device='cuda'):
+            if default_hyperparameters is None:
+                raise AttributeError('default_hyperparameters must be defined')
+            self._validate_hyperparameters(hyperparameters)
+            self._name = name
+            self._device = device
+            self._env = env
+            self._hyperparameters = {**default_hyperparameters, **hyperparameters}
 
-class PresetBuilder(ABC):
-    default_hyperparameters = None
+        def name(self, name):
+            return self.__class__(
+                name=_name,
+                device=self._device,
+                hyperparameters=self._hyperparameters,
+                env=self._env
+            )
 
-    def __init__(self, hyperparameters={}, env=None, device='cuda'):
-        if self.default_hyperparameters is None:
-            raise AttributeError('default_hyperparameters must be defined')
-        self._device = device
-        self._env = env
-        self._hyperparameters = {**self.default_hyperparameters, **hyperparameters}
+        def hyperparameters(self, **hyperparameters):
+            return self.__class__(
+                name=self._name,
+                device=self._device,
+                hyperparameters=hyperparameters,
+                env=self._env
+            )
 
-    def hyperparameters(self, **hyperparameters):
-        self._validate_hyperparameters(hyperparameters)
-        return self.__class__(
-            device=self._device,
-            hyperparameters={**self.default_hyperparameters, **hyperparameters},
-            env=self._env
-        )
+        def env(self, env):
+            return self.__class__(
+                name=self._name,
+                device=self._device,
+                hyperparameters=self._hyperparameters,
+                env=env
+            )
 
-    def env(self, env):
-        return self.__class__(
-            device=self._device,
-            hyperparameters=self._hyperparameters,
-            env=env
-        )
+        def device(self, device):
+            return self.__class__(name=self._name, device=device, hyperparameters=self._hyperparameters, env=self._env)
 
-    def device(self, device):
-        return self.__class__(device=device, hyperparameters=self._hyperparameters, env=self._env)
+        def _validate_hyperparameters(self, hyperparameters):
+            for key in hyperparameters.keys():
+                if key not in default_hyperparameters:
+                    raise KeyError("Invalid hyperparameter: {}".format(key))
 
-    def _validate_hyperparameters(self, hyperparameters):
-        for key in hyperparameters.keys():
-            if key not in self.default_hyperparameters:
-                raise KeyError("Invalid hyperparameter: {}".format(key))
+        def build(self):
+            return constructor(self._hyperparameters, self._env, self._device)
 
-    @abstractmethod
-    def build(self):
-        pass
+    return PresetBuilder

--- a/all/presets/classic_control/__init__.py
+++ b/all/presets/classic_control/__init__.py
@@ -1,24 +1,33 @@
 from .a2c import a2c, A2CClassicControlPreset
-from .c51 import c51
-from .ddqn import ddqn
-from .dqn import dqn
-from .ppo import ppo
-from .rainbow import rainbow
-from .vac import vac
-from .vpg import vpg
-from .vqn import vqn
-from .vsarsa import vsarsa
+from .c51 import c51, C51ClassicControlPreset
+from .ddqn import ddqn, DDQNClassicControlPreset
+from .dqn import dqn, DQNClassicControlPreset
+from .ppo import ppo, PPOClassicControlPreset
+from .rainbow import rainbow, RainbowClassicControlPreset
+from .vac import vac, VACClassicControlPreset
+from .vpg import vpg, VPGClassicControlPreset
+from .vqn import vqn, VQNClassicControlPreset
+from .vsarsa import vsarsa, VSarsaClassicControlPreset
 
 __all__ = [
     "a2c",
     "A2CClassicControlPreset",
     "c51",
+    "C51ClassicControlPreset",
     "ddqn",
+    "DDQNClassicControlPreset",
     "dqn",
+    "DQNClassicControlPreset",
     "ppo",
+    "PPOClassicControlPreset",
     "rainbow",
+    "RainbowClassicControlPreset",
     "vac",
+    "VACClassicControlPreset",
     "vpg",
+    "VPGClassicControlPreset",
     "vqn",
-    "vsarsa"
+    "VQNClassicControlPreset",
+    "vsarsa",
+    "VSarsaClassicControlPreset",
 ]

--- a/all/presets/classic_control/__init__.py
+++ b/all/presets/classic_control/__init__.py
@@ -1,4 +1,4 @@
-from .a2c import a2c
+from .a2c import a2c, A2CClassicControlPreset
 from .c51 import c51
 from .ddqn import ddqn
 from .dqn import dqn
@@ -11,6 +11,7 @@ from .vsarsa import vsarsa
 
 __all__ = [
     "a2c",
+    "A2CClassicControlPreset",
     "c51",
     "ddqn",
     "dqn",

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from all.agents import A2C, A2CTestAgent
 from all.approximation import VNetwork, FeatureNetwork
@@ -96,8 +97,8 @@ class A2CClassicControlPreset(Preset):
         )
 
     def test_agent(self):
-        features = FeatureNetwork(self.feature_model)
-        policy = SoftmaxPolicy(self.policy_model)
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return A2CTestAgent(features, policy)
 
 

--- a/all/presets/classic_control/a2c.py
+++ b/all/presets/classic_control/a2c.py
@@ -34,7 +34,7 @@ class A2CClassicControlPreset(Preset):
     Args:
         env (all.environments.GymEnvironment): The classic control environment for which to construct the agent.
         device (torch.device, optional): the device on which to load the agent
-    
+
     Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
@@ -49,6 +49,7 @@ class A2CClassicControlPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -98,5 +99,6 @@ class A2CClassicControlPreset(Preset):
         features = FeatureNetwork(self.feature_model)
         policy = SoftmaxPolicy(self.policy_model)
         return A2CTestAgent(features, policy)
+
 
 a2c = preset_builder('a2c', default_hyperparameters, A2CClassicControlPreset)

--- a/all/presets/classic_control/c51.py
+++ b/all/presets/classic_control/c51.py
@@ -34,6 +34,7 @@ default_hyperparameters = {
     "model_constructor": fc_relu_dist_q
 }
 
+
 class C51ClassicControlPreset(Preset):
     """
     Categorical DQN (C51) Atari preset.
@@ -61,6 +62,7 @@ class C51ClassicControlPreset(Preset):
         v_max (int): The expected return correspodning to the larget atom.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
@@ -116,5 +118,6 @@ class C51ClassicControlPreset(Preset):
             v_max=self.hyperparameters['v_max'],
         )
         return C51TestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"])
+
 
 c51 = preset_builder('c51', default_hyperparameters, C51ClassicControlPreset)

--- a/all/presets/classic_control/c51.py
+++ b/all/presets/classic_control/c51.py
@@ -39,7 +39,7 @@ class C51ClassicControlPreset(Preset):
     Categorical DQN (C51) Atari preset.
 
     Args:
-        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
         device (torch.device, optional): the device on which to load the agent
 
     Keyword Args:

--- a/all/presets/classic_control/c51.py
+++ b/all/presets/classic_control/c51.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from all.agents import C51, C51TestAgent
 from all.approximation import QDist, FixedTarget
@@ -107,7 +108,7 @@ class C51ClassicControlPreset(Preset):
 
     def test_agent(self):
         q_dist = QDist(
-            self.model,
+            copy.deepcopy(self.model),
             None,
             self.n_actions,
             self.hyperparameters['atoms'],

--- a/all/presets/classic_control/c51.py
+++ b/all/presets/classic_control/c51.py
@@ -1,88 +1,119 @@
 from torch.optim import Adam
-from all.agents import C51
-from all.approximation import QDist
+from all.agents import C51, C51TestAgent
+from all.approximation import QDist, FixedTarget
 from all.logging import DummyWriter
 from all.memory import ExperienceReplayBuffer
 from all.optim import LinearScheduler
 from .models import fc_relu_dist_q
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def c51(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-4,
-        # Training settings
-        minibatch_size=128,
-        update_frequency=1,
-        # Replay buffer settings
-        replay_start_size=1000,
-        replay_buffer_size=20000,
-        # Exploration settings
-        initial_exploration=1.00,
-        final_exploration=0.02,
-        final_exploration_frame=10000,
-        # Distributional RL
-        atoms=101,
-        v_min=-100,
-        v_max=100,
-        # Model construction
-        model_constructor=fc_relu_dist_q
-):
+default_hyperparameters = {
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-4,
+    # Training settings
+    "minibatch_size": 128,
+    "update_frequency": 1,
+    "target_update_frequency": 100,
+    # Replay buffer settings
+    "replay_start_size": 1000,
+    "replay_buffer_size": 20000,
+    # Exploration settings
+    "initial_exploration": 1.00,
+    "final_exploration": 0.02,
+    "final_exploration_step": 10000,
+    "test_exploration": 0.001,
+    # Distributional RL
+    "atoms": 101,
+    "v_min": -100,
+    "v_max": 100,
+    # Model construction
+    "model_constructor": fc_relu_dist_q
+}
+
+class C51ClassicControlPreset(Preset):
     """
-    C51 classic control preset.
+    Categorical DQN (C51) Atari preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         minibatch_size (int): Number of experiences to sample in each training update.
         update_frequency (int): Number of timesteps per training update.
+        target_update_frequency (int): Number of timesteps between updates the target network.
         replay_start_size (int): Number of experiences in replay buffer when training begins.
         replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
+        initial_exploration (float): Initial probability of choosing a random action,
             decayed over course of training.
-        final_exploration (int): Final probability of choosing a random action.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         atoms (int): The number of atoms in the categorical distribution used to represent
             the distributional value function.
         v_min (int): The expected return corresponding to the smallest atom.
         v_max (int): The expected return correspodning to the larget atom.
         model_constructor (function): The function used to construct the neural model.
     """
-    def _c51(env, writer=DummyWriter()):
-        model = model_constructor(env, atoms=atoms).to(device)
-        optimizer = Adam(model.parameters(), lr=lr)
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__()
+        self.model = hyperparameters['model_constructor'](env, atoms=hyperparameters['atoms']).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
+
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        optimizer = Adam(self.model.parameters(), lr=self.hyperparameters['lr'])
+
         q = QDist(
-            model,
+            self.model,
             optimizer,
-            env.action_space.n,
-            atoms,
-            v_min=v_min,
-            v_max=v_max,
+            self.n_actions,
+            self.hyperparameters['atoms'],
+            v_min=self.hyperparameters['v_min'],
+            v_max=self.hyperparameters['v_max'],
+            target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer,
         )
-        replay_buffer = ExperienceReplayBuffer(replay_buffer_size, device=device)
+
+        replay_buffer = ExperienceReplayBuffer(
+            self.hyperparameters['replay_buffer_size'],
+            device=self.device
+        )
+
         return C51(
             q,
             replay_buffer,
             exploration=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                replay_start_size,
-                final_exploration_frame,
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                0,
+                self.hyperparameters["final_exploration_step"] - self.hyperparameters["replay_start_size"],
                 name="epsilon",
                 writer=writer,
             ),
-            discount_factor=discount_factor,
-            minibatch_size=minibatch_size,
-            replay_start_size=replay_start_size,
-            update_frequency=update_frequency,
+            discount_factor=self.hyperparameters["discount_factor"],
+            minibatch_size=self.hyperparameters["minibatch_size"],
+            replay_start_size=self.hyperparameters["replay_start_size"],
+            update_frequency=self.hyperparameters["update_frequency"],
             writer=writer
         )
 
-    return _c51
+    def test_agent(self):
+        q_dist = QDist(
+            self.model,
+            None,
+            self.n_actions,
+            self.hyperparameters['atoms'],
+            v_min=self.hyperparameters['v_min'],
+            v_max=self.hyperparameters['v_max'],
+        )
+        return C51TestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"])
 
-
-__all__ = ["c51"]
+c51 = preset_builder('c51', default_hyperparameters, C51ClassicControlPreset)

--- a/all/presets/classic_control/ddqn.py
+++ b/all/presets/classic_control/ddqn.py
@@ -72,8 +72,6 @@ class DDQNClassicControlPreset(Preset):
         self.device = device
 
     def agent(self, writer=DummyWriter(), train_steps=float('inf')):
-        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
-
         optimizer = Adam(self.model.parameters(), lr=self.hyperparameters['lr'])
 
         q = QNetwork(

--- a/all/presets/classic_control/ddqn.py
+++ b/all/presets/classic_control/ddqn.py
@@ -35,6 +35,32 @@ default_hyperparameters = {
 }
 
 class DDQNClassicControlPreset(Preset):
+    """
+    Dueling Double DQN (DDQN) with Prioritized Experience Replay (PER) Classic Control Preset.
+
+    Args:
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+
+    Keyword Args:
+        discount_factor (float): Discount factor for future rewards.
+        lr (float): Learning rate for the Adam optimizer.
+        minibatch_size (int): Number of experiences to sample in each training update.
+        update_frequency (int): Number of timesteps per training update.
+        target_update_frequency (int): Number of timesteps between updates the target network.
+        replay_start_size (int): Number of experiences in replay buffer when training begins.
+        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
+        alpha (float): Amount of prioritization in the prioritized experience replay buffer.
+            (0 = no prioritization, 1 = full prioritization)
+        beta (float): The strength of the importance sampling correction for prioritized experience replay.
+            (0 = no correction, 1 = full correction)
+        model_constructor (function): The function used to construct the neural model.
+    """
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()

--- a/all/presets/classic_control/ddqn.py
+++ b/all/presets/classic_control/ddqn.py
@@ -1,92 +1,92 @@
+import copy
 from torch.optim import Adam
-from all.agents import DDQN
+from all.agents import DDQN, DDQNTestAgent
 from all.approximation import QNetwork, FixedTarget
 from all.logging import DummyWriter
 from all.memory import PrioritizedReplayBuffer
 from all.optim import LinearScheduler
 from all.policies import GreedyPolicy
 from .models import dueling_fc_relu_q
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ddqn(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-3,
-        # Training settings
-        minibatch_size=64,
-        update_frequency=1,
-        target_update_frequency=100,
-        # Replay buffer settings
-        replay_start_size=1000,
-        replay_buffer_size=10000,
-        # Exploration settings
-        initial_exploration=1.,
-        final_exploration=0.,
-        final_exploration_frame=10000,
-        # Prioritized replay settings
-        alpha=0.2,
-        beta=0.6,
-        # Model construction
-        model_constructor=dueling_fc_relu_q
-):
-    """
-    Dueling Double DQN with Prioritized Experience Replay (PER).
+default_hyperparameters = {
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-3,
+    # Training settings
+    "minibatch_size": 64,
+    "update_frequency": 1,
+    "target_update_frequency": 100,
+    # Replay buffer settings
+    "replay_start_size": 1000,
+    "replay_buffer_size": 10000,
+    # Exploration settings
+    "initial_exploration": 1.,
+    "final_exploration": 0.,
+    "final_exploration_step": 10000,
+    "test_exploration": 0.001,
+    # Prioritized replay settings
+    "alpha": 0.2,
+    "beta": 0.6,
+    # Model construction
+    "model_constructor": dueling_fc_relu_q
+}
 
-    Args:
-        device (str): The device to load parameters and buffers onto for this agent.
-        discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
-        lr (float): Learning rate for the Adam optimizer.
-        minibatch_size (int): Number of experiences to sample in each training update.
-        update_frequency (int): Number of timesteps per training update.
-        target_update_frequency (int): Number of timesteps between updates the target network.
-        replay_start_size (int): Number of experiences in replay buffer when training begins.
-        replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
-        alpha (float): Amount of prioritization in the prioritized experience replay buffer.
-            (0 = no prioritization, 1 = full prioritization)
-        beta (float): The strength of the importance sampling correction for prioritized experience replay.
-            (0 = no correction, 1 = full correction)
-        model_constructor (function): The function used to construct the neural model.
-    """
-    def _ddqn(env, writer=DummyWriter()):
-        model = model_constructor(env).to(device)
-        optimizer = Adam(model.parameters(), lr=lr)
-        q = QNetwork(
-            model,
-            optimizer,
-            target=FixedTarget(target_update_frequency),
-            writer=writer
-        )
-        policy = GreedyPolicy(
-            q,
-            env.action_space.n,
-            epsilon=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                replay_start_size,
-                final_exploration_frame,
-                name="epsilon",
+class DDQNClassicControlPreset(Preset):
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__()
+        self.model = hyperparameters['model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
+
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+            n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
+
+            optimizer = Adam(self.model.parameters(), lr=self.hyperparameters['lr'])
+
+            q = QNetwork(
+                self.model,
+                optimizer,
+                target=FixedTarget(self.hyperparameters['target_update_frequency']),
                 writer=writer
             )
-        )
-        replay_buffer = PrioritizedReplayBuffer(
-            replay_buffer_size,
-            alpha=alpha,
-            beta=beta,
-            device=device
-        )
-        return DDQN(q, policy, replay_buffer,
-                    discount_factor=discount_factor,
-                    replay_start_size=replay_start_size,
-                    update_frequency=update_frequency,
-                    minibatch_size=minibatch_size)
-    return _ddqn
 
+            policy = GreedyPolicy(
+                q,
+                self.n_actions,
+                epsilon=LinearScheduler(
+                    self.hyperparameters['initial_exploration'],
+                    self.hyperparameters['final_exploration'],
+                    self.hyperparameters['replay_start_size'],
+                    self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
+                    name="exploration",
+                    writer=writer
+                )
+            )
 
-__all__ = ["ddqn"]
+            replay_buffer = PrioritizedReplayBuffer(
+                self.hyperparameters['replay_buffer_size'],
+                alpha=self.hyperparameters['alpha'],
+                beta=self.hyperparameters['beta'],
+                device=self.device
+            )
+
+            return DDQN(
+                q,
+                policy,
+                replay_buffer,
+                discount_factor=self.hyperparameters["discount_factor"],
+                minibatch_size=self.hyperparameters["minibatch_size"],
+                replay_start_size=self.hyperparameters["replay_start_size"],
+                update_frequency=self.hyperparameters["update_frequency"],
+            )
+
+    def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
+        return DDQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+
+ddqn = preset_builder('ddqn', default_hyperparameters, DDQNClassicControlPreset)

--- a/all/presets/classic_control/dqn.py
+++ b/all/presets/classic_control/dqn.py
@@ -1,84 +1,110 @@
+import copy
 from torch.optim import Adam
-from all.agents import DQN
+from all.agents import DQN, DQNTestAgent
 from all.approximation import QNetwork, FixedTarget
 from all.logging import DummyWriter
 from all.memory import ExperienceReplayBuffer
 from all.optim import LinearScheduler
 from all.policies import GreedyPolicy
 from .models import fc_relu_q
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def dqn(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-3,
-        # Training settings
-        minibatch_size=64,
-        update_frequency=1,
-        target_update_frequency=100,
-        # Replay buffer settings
-        replay_start_size=1000,
-        replay_buffer_size=10000,
-        # Exploration settings
-        initial_exploration=1.,
-        final_exploration=0.,
-        final_exploration_frame=10000,
-        # Model construction
-        model_constructor=fc_relu_q
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-3,
+    # Training settings
+    "minibatch_size": 64,
+    "update_frequency": 1,
+    "target_update_frequency": 100,
+    # Replay buffer settings
+    "replay_start_size": 1000,
+    "replay_buffer_size": 10000,
+    # Explicit exploration
+    "initial_exploration": 1.,
+    "final_exploration": 0.,
+    "final_exploration_step": 10000,
+    "test_exploration": 0.001,
+    # Model construction
+    "model_constructor": fc_relu_q
+}
+
+class DQNClassicControlPreset(Preset):
     """
-    DQN classic control preset.
+    Deep Q-Network (DQN) Classic Control Preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
-        discount_factor (float): Discount factor for future rewards.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
+        discount_factor (float, optional): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         minibatch_size (int): Number of experiences to sample in each training update.
         update_frequency (int): Number of timesteps per training update.
         target_update_frequency (int): Number of timesteps between updates the target network.
         replay_start_size (int): Number of experiences in replay buffer when training begins.
         replay_buffer_size (int): Maximum number of experiences to store in the replay buffer.
-        initial_exploration (int): Initial probability of choosing a random action,
-            decayed until final_exploration_frame.
-        final_exploration (int): Final probability of choosing a random action.
-        final_exploration_frame (int): The frame where the exploration decay stops.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         model_constructor (function): The function used to construct the neural model.
     """
-    def _dqn(env, writer=DummyWriter()):
-        model = model_constructor(env).to(device)
-        optimizer = Adam(model.parameters(), lr=lr)
+    def __init__(self, env, device="cuda", **hyperparameters):
+        super().__init__()
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        self.model = hyperparameters['model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
+
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
+
+        optimizer = Adam(self.model.parameters(), lr=self.hyperparameters['lr'])
+
         q = QNetwork(
-            model,
+            self.model,
             optimizer,
-            target=FixedTarget(target_update_frequency),
+            target=FixedTarget(self.hyperparameters['target_update_frequency']),
             writer=writer
         )
+
         policy = GreedyPolicy(
             q,
-            env.action_space.n,
+            self.n_actions,
             epsilon=LinearScheduler(
-                initial_exploration,
-                final_exploration,
-                replay_start_size,
-                final_exploration_frame,
-                name="epsilon",
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                self.hyperparameters['replay_start_size'],
+                self.hyperparameters['final_exploration_step'] - self.hyperparameters['replay_start_size'],
+                name="exploration",
                 writer=writer
             )
         )
+
         replay_buffer = ExperienceReplayBuffer(
-            replay_buffer_size, device=device)
+            self.hyperparameters['replay_buffer_size'],
+            device=self.device
+        )
+
         return DQN(
             q,
             policy,
             replay_buffer,
-            discount_factor=discount_factor,
-            minibatch_size=minibatch_size,
-            replay_start_size=replay_start_size,
-            update_frequency=update_frequency,
+            discount_factor=self.hyperparameters['discount_factor'],
+            minibatch_size=self.hyperparameters['minibatch_size'],
+            replay_start_size=self.hyperparameters['replay_start_size'],
+            update_frequency=self.hyperparameters['update_frequency'],
         )
-    return _dqn
 
+    def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
+        return DQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
 
-__all__ = ["dqn"]
+dqn = preset_builder('dqn', default_hyperparameters, DQNClassicControlPreset)

--- a/all/presets/classic_control/dqn.py
+++ b/all/presets/classic_control/dqn.py
@@ -66,8 +66,6 @@ class DQNClassicControlPreset(Preset):
         self.device = device
 
     def agent(self, writer=DummyWriter(), train_steps=float('inf')):
-        n_updates = (train_steps - self.hyperparameters['replay_start_size']) / self.hyperparameters['update_frequency']
-
         optimizer = Adam(self.model.parameters(), lr=self.hyperparameters['lr'])
 
         q = QNetwork(

--- a/all/presets/classic_control/dqn.py
+++ b/all/presets/classic_control/dqn.py
@@ -32,6 +32,7 @@ default_hyperparameters = {
     "model_constructor": fc_relu_q
 }
 
+
 class DQNClassicControlPreset(Preset):
     """
     Deep Q-Network (DQN) Classic Control Preset.
@@ -55,6 +56,7 @@ class DQNClassicControlPreset(Preset):
         test_exploration (float): The exploration rate of the test Agent
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -104,7 +106,8 @@ class DQNClassicControlPreset(Preset):
         )
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return DQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+
 
 dqn = preset_builder('dqn', default_hyperparameters, DQNClassicControlPreset)

--- a/all/presets/classic_control/ppo.py
+++ b/all/presets/classic_control/ppo.py
@@ -1,44 +1,60 @@
+import copy
 from torch.optim import Adam
-from all.agents import PPO
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from all.agents import PPO, PPOTestAgent
+from all.bodies import DeepmindAtariBody
 from all.approximation import VNetwork, FeatureNetwork
 from all.logging import DummyWriter
+from all.optim import LinearScheduler
 from all.policies import SoftmaxPolicy
 from .models import fc_relu_features, fc_policy_head, fc_value_head
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ppo(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-3,
-        # Other optimization settings
-        clip_grad=0.1,
-        entropy_loss_scaling=0.001,
-        epsilon=0.2,
-        # Batch settings
-        epochs=4,
-        minibatches=4,
-        n_envs=8,
-        n_steps=8,
-        # GAE settings
-        lam=0.95,
-        # Model construction
-        feature_model_constructor=fc_relu_features,
-        value_model_constructor=fc_value_head,
-        policy_model_constructor=fc_policy_head
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-3,
+    "eps": 1.5e-4,
+    # Other optimization settings
+    "clip_grad": 0.1,
+    "entropy_loss_scaling": 0.001,
+    "value_loss_scaling": 0.5,
+    "clip_initial": 0.1,
+    "clip_final": 0.01,
+    # Batch settings
+    "epochs": 4,
+    "minibatches": 4,
+    "n_envs": 8,
+    "n_steps": 8,
+    # GAE settings
+    "lam": 0.95,
+    # Model construction
+    "feature_model_constructor": fc_relu_features,
+    "value_model_constructor": fc_value_head,
+    "policy_model_constructor": fc_policy_head
+}
+
+class PPOClassicControlPreset(Preset):
     """
-    PPO classic control preset.
+    Proximal Policy Optimization (PPO) Classic Control preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
+        eps (float): Stability parameters for the Adam optimizer.
         clip_grad (float): The maximum magnitude of the gradient for any given parameter.
             Set to 0 to disable.
         entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
-        epsilon (float): Value for epsilon in the clipped PPO objective function.
+        value_loss_scaling (float): Coefficient for the value function loss.
+        clip_initial (float): Value for epsilon in the clipped PPO objective function at the beginning of training.
+        clip_final (float): Value for epsilon in the clipped PPO objective function at the end of training.
         epochs (int): Number of times to iterature through each batch.
         minibatches (int): The number of minibatches to split each batch into.
         n_envs (int): Number of parallel actors.
@@ -48,45 +64,69 @@ def ppo(
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _ppo(envs, writer=DummyWriter()):
-        env = envs[0]
-        feature_model = feature_model_constructor(env).to(device)
-        value_model = value_model_constructor().to(device)
-        policy_model = policy_model_constructor(env).to(device)
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
 
-        feature_optimizer = Adam(feature_model.parameters(), lr=lr)
-        value_optimizer = Adam(value_model.parameters(), lr=lr)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps * self.hyperparameters['epochs'] * self.hyperparameters['minibatches'] / (self.hyperparameters['n_steps'] * self.hyperparameters['n_envs'])
+
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr"], eps=self.hyperparameters["eps"])
 
         features = FeatureNetwork(
-            feature_model, feature_optimizer, clip_grad=clip_grad)
+            self.feature_model,
+            feature_optimizer,
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
+        )
+
         v = VNetwork(
-            value_model,
+            self.value_model,
             value_optimizer,
-            clip_grad=clip_grad,
+            loss_scaling=self.hyperparameters["value_loss_scaling"],
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         policy = SoftmaxPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
-            clip_grad=clip_grad,
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         return PPO(
             features,
             v,
             policy,
-            epsilon=epsilon,
-            epochs=epochs,
-            lam=lam,
-            minibatches=minibatches,
-            n_envs=n_envs,
-            n_steps=n_steps,
-            discount_factor=discount_factor,
-            entropy_loss_scaling=entropy_loss_scaling,
-            writer=writer
+            epsilon=LinearScheduler(
+                self.hyperparameters["clip_initial"],
+                self.hyperparameters["clip_final"],
+                0,
+                n_updates,
+                name='clip',
+                writer=writer
+            ),
+            epochs=self.hyperparameters["epochs"],
+            minibatches=self.hyperparameters["minibatches"],
+            n_envs=self.hyperparameters["n_envs"],
+            n_steps=self.hyperparameters["n_steps"],
+            discount_factor=self.hyperparameters["discount_factor"],
+            lam=self.hyperparameters["lam"],
+            entropy_loss_scaling=self.hyperparameters["entropy_loss_scaling"],
+            writer=writer,
         )
-    return _ppo, n_envs
 
+    def test_agent(self):
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
+        return PPOTestAgent(features, policy)
 
-__all__ = ["ppo"]
+ppo = preset_builder('ppo', default_hyperparameters, PPOClassicControlPreset)

--- a/all/presets/classic_control/ppo.py
+++ b/all/presets/classic_control/ppo.py
@@ -37,6 +37,7 @@ default_hyperparameters = {
     "policy_model_constructor": fc_policy_head
 }
 
+
 class PPOClassicControlPreset(Preset):
     """
     Proximal Policy Optimization (PPO) Classic Control preset.
@@ -64,6 +65,7 @@ class PPOClassicControlPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -128,5 +130,6 @@ class PPOClassicControlPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return PPOTestAgent(features, policy)
+
 
 ppo = preset_builder('ppo', default_hyperparameters, PPOClassicControlPreset)

--- a/all/presets/classic_control/rainbow.py
+++ b/all/presets/classic_control/rainbow.py
@@ -47,7 +47,7 @@ class RainbowClassicControlPreset(Preset):
     Rainbow DQN Classic Control Preset.
 
     Args:
-        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
         device (torch.device, optional): The device on which to load the agent.
 
     Keyword Args:

--- a/all/presets/classic_control/rainbow.py
+++ b/all/presets/classic_control/rainbow.py
@@ -42,6 +42,7 @@ default_hyperparameters = {
     "model_constructor": fc_relu_rainbow
 }
 
+
 class RainbowClassicControlPreset(Preset):
     """
     Rainbow DQN Classic Control Preset.
@@ -74,6 +75,7 @@ class RainbowClassicControlPreset(Preset):
         sigma (float): Initial noisy network noise.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -112,22 +114,22 @@ class RainbowClassicControlPreset(Preset):
         )
 
         return Rainbow(
-                q_dist,
-                replay_buffer,
-                exploration=LinearScheduler(
-                    self.hyperparameters['initial_exploration'],
-                    self.hyperparameters['final_exploration'],
-                    0,
-                    train_steps - self.hyperparameters['replay_start_size'],
-                    name="exploration",
-                    writer=writer
-                ),
-                discount_factor=self.hyperparameters['discount_factor'] ** self.hyperparameters["n_steps"],
-                minibatch_size=self.hyperparameters['minibatch_size'],
-                replay_start_size=self.hyperparameters['replay_start_size'],
-                update_frequency=self.hyperparameters['update_frequency'],
-                writer=writer,
-            )
+            q_dist,
+            replay_buffer,
+            exploration=LinearScheduler(
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                0,
+                train_steps - self.hyperparameters['replay_start_size'],
+                name="exploration",
+                writer=writer
+            ),
+            discount_factor=self.hyperparameters['discount_factor'] ** self.hyperparameters["n_steps"],
+            minibatch_size=self.hyperparameters['minibatch_size'],
+            replay_start_size=self.hyperparameters['replay_start_size'],
+            update_frequency=self.hyperparameters['update_frequency'],
+            writer=writer,
+        )
 
     def test_agent(self):
         q_dist = QDist(
@@ -139,5 +141,6 @@ class RainbowClassicControlPreset(Preset):
             v_max=self.hyperparameters['v_max'],
         )
         return RainbowTestAgent(q_dist, self.n_actions, self.hyperparameters["test_exploration"])
+
 
 rainbow = preset_builder('rainbow', default_hyperparameters, RainbowClassicControlPreset)

--- a/all/presets/classic_control/vac.py
+++ b/all/presets/classic_control/vac.py
@@ -28,6 +28,7 @@ default_hyperparameters = {
     "policy_model_constructor": fc_policy_head
 }
 
+
 class VACClassicControlPreset(Preset):
     """
     Vanilla Actor-Critic (VAC) Classic Control preset.
@@ -49,6 +50,7 @@ class VACClassicControlPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -93,5 +95,6 @@ class VACClassicControlPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return VACTestAgent(features, policy)
+
 
 vac = preset_builder('vac', default_hyperparameters, VACClassicControlPreset)

--- a/all/presets/classic_control/vac.py
+++ b/all/presets/classic_control/vac.py
@@ -1,49 +1,97 @@
+import copy
 from torch.optim import Adam
-from all.agents import VAC
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from all.agents import VAC, VACTestAgent
 from all.approximation import VNetwork, FeatureNetwork
+from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.policies import SoftmaxPolicy
 from .models import fc_relu_features, fc_policy_head, fc_value_head
+from ..builder import preset_builder
+from ..preset import Preset
 
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr_v": 5e-4,
+    "lr_pi": 1e-4,
+    "eps": 1.5e-4,
+    # Other optimization settings
+    "clip_grad": 0.5,
+    "value_loss_scaling": 0.25,
+    # Parallel actors
+    "n_envs": 16,
+    # Model construction
+    "feature_model_constructor": fc_relu_features,
+    "value_model_constructor": fc_value_head,
+    "policy_model_constructor": fc_policy_head
+}
 
-def vac(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr_v=5e-3,
-        lr_pi=1e-3,
-        eps=1e-5,
-        # Model construction
-        feature_model_constructor=fc_relu_features,
-        value_model_constructor=fc_value_head,
-        policy_model_constructor=fc_policy_head
-):
+class VACClassicControlPreset(Preset):
     """
-    Vanilla Actor-Critic classic control preset.
+    Vanilla Actor-Critic (VAC) Classic Control preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr_v (float): Learning rate for value network.
         lr_pi (float): Learning rate for policy network and feature network.
         eps (float): Stability parameters for the Adam optimizer.
+        clip_grad (float): The maximum magnitude of the gradient for any given parameter.
+            Set to 0 to disable.
+        value_loss_scaling (float): Coefficient for the value function loss.
+        n_envs (int): Number of parallel environments.
         feature_model_constructor (function): The function used to construct the neural feature model.
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _vac(env, writer=DummyWriter()):
-        value_model = value_model_constructor().to(device)
-        policy_model = policy_model_constructor(env).to(device)
-        feature_model = feature_model_constructor(env).to(device)
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
 
-        value_optimizer = Adam(value_model.parameters(), lr=lr_v, eps=eps)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr_pi, eps=eps)
-        feature_optimizer = Adam(feature_model.parameters(), lr=lr_pi, eps=eps)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps / self.hyperparameters["n_envs"]
 
-        v = VNetwork(value_model, value_optimizer, writer=writer)
-        policy = SoftmaxPolicy(policy_model, policy_optimizer, writer=writer)
-        features = FeatureNetwork(feature_model, feature_optimizer)
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr_v"], eps=self.hyperparameters["eps"])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
 
-        return VAC(features, v, policy, discount_factor=discount_factor)
-    return _vac
+        features = FeatureNetwork(
+            self.feature_model,
+            feature_optimizer,
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
+        )
+
+        v = VNetwork(
+            self.value_model,
+            value_optimizer,
+            loss_scaling=self.hyperparameters["value_loss_scaling"],
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
+        )
+
+        policy = SoftmaxPolicy(
+            self.policy_model,
+            policy_optimizer,
+            clip_grad=self.hyperparameters["clip_grad"],
+            writer=writer
+        )
+
+        return VAC(features, v, policy, discount_factor=self.hyperparameters["discount_factor"])
+
+    def test_agent(self):
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
+        return VACTestAgent(features, policy)
+
+vac = preset_builder('vac', default_hyperparameters, VACClassicControlPreset)

--- a/all/presets/classic_control/vac.py
+++ b/all/presets/classic_control/vac.py
@@ -61,8 +61,6 @@ class VACClassicControlPreset(Preset):
         self.device = device
 
     def agent(self, writer=DummyWriter(), train_steps=float('inf')):
-        n_updates = train_steps / self.hyperparameters["n_envs"]
-
         feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
         value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr_v"], eps=self.hyperparameters["eps"])
         policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])

--- a/all/presets/classic_control/vpg.py
+++ b/all/presets/classic_control/vpg.py
@@ -1,64 +1,97 @@
+import copy
 from torch.optim import Adam
-from all.agents import VPG
+from torch.optim.lr_scheduler import CosineAnnealingLR
+from all.agents import VPG, VPGTestAgent
 from all.approximation import VNetwork, FeatureNetwork
+from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
 from all.policies import SoftmaxPolicy
 from .models import fc_relu_features, fc_policy_head, fc_value_head
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def vpg(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=5e-3,
-        # Batch settings
-        min_batch_size=500,
-        # Model construction
-        feature_model_constructor=fc_relu_features,
-        value_model_constructor=fc_value_head,
-        policy_model_constructor=fc_policy_head
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr_v": 5e-3,
+    "lr_pi": 1e-4,
+    "eps": 1.5e-4,
+    # Other optimization settings
+    "clip_grad": 0.5,
+    "value_loss_scaling": 0.25,
+    "min_batch_size": 500,
+    # Model construction
+    "feature_model_constructor": fc_relu_features,
+    "value_model_constructor": fc_value_head,
+    "policy_model_constructor": fc_policy_head
+}
+
+class VPGClassicControlPreset(Preset):
     """
-    Vanilla Policy Gradient classic control preset.
+    Vanilla Policy Gradient (VPG) Classic Control preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.GymEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
+        eps (float): Stability parameters for the Adam optimizer.
+        clip_grad (float): The maximum magnitude of the gradient for any given parameter.
+            Set to 0 to disable.
+        value_loss_scaling (float): Coefficient for the value function loss.
         min_batch_size (int): Continue running complete episodes until at least this many
             states have been seen since the last update.
         feature_model_constructor (function): The function used to construct the neural feature model.
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _vpg(env, writer=DummyWriter()):
-        feature_model = feature_model_constructor(env).to(device)
-        value_model = value_model_constructor().to(device)
-        policy_model = policy_model_constructor(env).to(device)
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__()
+        self.value_model = hyperparameters['value_model_constructor']().to(device)
+        self.policy_model = hyperparameters['policy_model_constructor'](env).to(device)
+        self.feature_model = hyperparameters['feature_model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
 
-        feature_optimizer = Adam(feature_model.parameters(), lr=lr)
-        value_optimizer = Adam(value_model.parameters(), lr=lr)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps / self.hyperparameters["min_batch_size"]
+
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr_v"], eps=self.hyperparameters["eps"])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
 
         features = FeatureNetwork(
-            feature_model,
+            self.feature_model,
             feature_optimizer,
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         v = VNetwork(
-            value_model,
+            self.value_model,
             value_optimizer,
+            loss_scaling=self.hyperparameters["value_loss_scaling"],
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
+
         policy = SoftmaxPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
+            clip_grad=self.hyperparameters["clip_grad"],
             writer=writer
         )
-        return VPG(features, v, policy, discount_factor=discount_factor, min_batch_size=min_batch_size)
-    return _vpg
 
+        return VPG(features, v, policy, discount_factor=self.hyperparameters["discount_factor"], min_batch_size=self.hyperparameters["min_batch_size"])
 
-__all__ = ["vpg"]
+    def test_agent(self):
+        features = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
+        return VPGTestAgent(features, policy)
+
+vpg = preset_builder('vpg', default_hyperparameters, VPGClassicControlPreset)

--- a/all/presets/classic_control/vpg.py
+++ b/all/presets/classic_control/vpg.py
@@ -28,6 +28,7 @@ default_hyperparameters = {
     "policy_model_constructor": fc_policy_head
 }
 
+
 class VPGClassicControlPreset(Preset):
     """
     Vanilla Policy Gradient (VPG) Classic Control preset.
@@ -49,6 +50,7 @@ class VPGClassicControlPreset(Preset):
         value_model_constructor (function): The function used to construct the neural value model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__()
@@ -93,5 +95,6 @@ class VPGClassicControlPreset(Preset):
         features = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = SoftmaxPolicy(copy.deepcopy(self.policy_model))
         return VPGTestAgent(features, policy)
+
 
 vpg = preset_builder('vpg', default_hyperparameters, VPGClassicControlPreset)

--- a/all/presets/classic_control/vpg.py
+++ b/all/presets/classic_control/vpg.py
@@ -61,8 +61,6 @@ class VPGClassicControlPreset(Preset):
         self.device = device
 
     def agent(self, writer=DummyWriter(), train_steps=float('inf')):
-        n_updates = train_steps / self.hyperparameters["min_batch_size"]
-
         feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])
         value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters["lr_v"], eps=self.hyperparameters["eps"])
         policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr_pi"], eps=self.hyperparameters["eps"])

--- a/all/presets/classic_control/vqn.py
+++ b/all/presets/classic_control/vqn.py
@@ -32,7 +32,7 @@ default_hyperparameters = {
 
 class VQNClassicControlPreset(Preset):
     """
-    Vanilla Q-Network (VQN) Classic Control preset.
+    Vanilla Q-Network (VQN) Classic Control Preset.
 
     Args:
         env (all.environments.AtariEnvironment): The environment for which to construct the agent.

--- a/all/presets/classic_control/vqn.py
+++ b/all/presets/classic_control/vqn.py
@@ -50,6 +50,7 @@ class VQNClassicControlPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -90,7 +91,8 @@ class VQNClassicControlPreset(Preset):
         return VQN(q, policy, discount_factor=self.hyperparameters['discount_factor'])
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return VQNTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+
 
 vqn = preset_builder('vqn', default_hyperparameters, VQNClassicControlPreset)

--- a/all/presets/classic_control/vsarsa.py
+++ b/all/presets/classic_control/vsarsa.py
@@ -1,42 +1,96 @@
+import copy
 from torch.optim import Adam
-from all.agents import VSarsa
+from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.approximation import QNetwork
-from all.policies import ParallelGreedyPolicy
+from all.agents import VSarsa, VSarsaTestAgent
+from all.bodies import DeepmindAtariBody
 from all.logging import DummyWriter
-from .models import fc_relu_q
+from all.optim import LinearScheduler
+from all.policies import ParallelGreedyPolicy
+from .models import dueling_fc_relu_q
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def vsarsa(
-        # Common settings
-        device="cpu",
-        discount_factor=0.99,
-        # Adam optimizer settings
-        lr=1e-2,
-        eps=1e-5,
-        # Exploration settings
-        epsilon=0.1,
-        # Parallel actors
-        n_envs=8,
-        # Model construction
-        model_constructor=fc_relu_q
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.99,
+    # Adam optimizer settings
+    "lr": 1e-2,
+    "eps": 1.5e-4,
+    # Explicit exploration
+    "initial_exploration": 1.,
+    "final_exploration": 0.,
+    "final_exploration_step": 10000,
+    "test_exploration": 0.001,
+    # Parallel actors
+    "n_envs": 8,
+    # Model construction
+    "model_constructor": dueling_fc_relu_q
+}
+
+
+class VSarsaClassicControlPreset(Preset):
     """
-    Vanilla SARSA classic control preset.
+    Vanilla SARSA (VSarsa) Classic Control Preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.AtariEnvironment): The environment for which to construct the agent.
+        device (torch.device, optional): The device on which to load the agent.
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
-        epsilon (int): Probability of choosing a random action.
+        initial_exploration (float): Initial probability of choosing a random action,
+            decayed over course of training.
+        final_exploration (float): Final probability of choosing a random action.
+        final_exploration_step (int): The step at which exploration decay is finished
+        test_exploration (float): The exploration rate of the test Agent
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
-    def _vsarsa(envs, writer=DummyWriter()):
-        env = envs[0]
-        model = model_constructor(env).to(device)
-        optimizer = Adam(model.parameters(), lr=lr, eps=eps)
-        q = QNetwork(model, optimizer, writer=writer)
-        policy = ParallelGreedyPolicy(q, env.action_space.n, epsilon=epsilon)
-        return VSarsa(q, policy, discount_factor=discount_factor)
-    return _vsarsa, n_envs
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__(n_envs=hyperparameters['n_envs'])
+        self.model = hyperparameters['model_constructor'](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.n_actions = env.action_space.n
+        self.device = device
+
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps / self.hyperparameters['n_envs']
+
+        optimizer = Adam(
+            self.model.parameters(),
+            lr=self.hyperparameters['lr'],
+            eps=self.hyperparameters['eps']
+        )
+
+        q = QNetwork(
+            self.model,
+            optimizer,
+            scheduler=CosineAnnealingLR(optimizer, n_updates),
+            writer=writer
+        )
+
+        policy = ParallelGreedyPolicy(
+            q,
+            self.n_actions,
+            epsilon=LinearScheduler(
+                self.hyperparameters['initial_exploration'],
+                self.hyperparameters['final_exploration'],
+                0,
+                self.hyperparameters["final_exploration_step"] / self.hyperparameters["n_envs"],
+                name="exploration",
+                writer=writer
+            )
+        )
+
+        return VSarsa(q, policy, discount_factor=self.hyperparameters['discount_factor'])
+
+    def test_agent(self):
+        q =  QNetwork(copy.deepcopy(self.model))
+        return VSarsaTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+
+vsarsa = preset_builder('vsarsa', default_hyperparameters, VSarsaClassicControlPreset)

--- a/all/presets/classic_control/vsarsa.py
+++ b/all/presets/classic_control/vsarsa.py
@@ -50,6 +50,7 @@ class VSarsaClassicControlPreset(Preset):
         n_envs (int): Number of parallel environments.
         model_constructor (function): The function used to construct the neural model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(n_envs=hyperparameters['n_envs'])
@@ -90,7 +91,8 @@ class VSarsaClassicControlPreset(Preset):
         return VSarsa(q, policy, discount_factor=self.hyperparameters['discount_factor'])
 
     def test_agent(self):
-        q =  QNetwork(copy.deepcopy(self.model))
+        q = QNetwork(copy.deepcopy(self.model))
         return VSarsaTestAgent(q, self.n_actions, exploration=self.hyperparameters['test_exploration'])
+
 
 vsarsa = preset_builder('vsarsa', default_hyperparameters, VSarsaClassicControlPreset)

--- a/all/presets/classic_control_test.py
+++ b/all/presets/classic_control_test.py
@@ -1,0 +1,75 @@
+import os
+import unittest
+import torch
+from all.environments import GymEnvironment
+from all.logging import DummyWriter
+from all.presets.classic_control import (
+    a2c,
+    c51,
+    ddqn,
+    dqn,
+    ppo,
+    rainbow,
+    vac,
+    vpg,
+    vqn,
+    vsarsa,
+)
+
+
+class TestAtariPresets(unittest.TestCase):
+    def setUp(self):
+        self.env = GymEnvironment('CartPole-v0')
+        self.env.reset()
+
+    def tearDown(self):
+        if os.path.exists('test_preset.pt'):
+            os.remove('test_preset.pt')
+
+    def test_a2c(self):
+        self.validate(a2c)
+
+    def test_c51(self):
+        self.validate(c51)
+
+    def test_ddqn(self):
+        self.validate(ddqn)
+
+    def test_dqn(self):
+        self.validate(dqn)
+
+    def test_ppo(self):
+        self.validate(ppo)
+
+    def test_rainbow(self):
+        self.validate(rainbow)
+
+    def test_vac(self):
+        self.validate(vac)
+
+    def test_vpg(self):
+        self.validate(vpg)
+
+    def test_vsarsa(self):
+        self.validate(vsarsa)
+
+    def test_vqn(self):
+        self.validate(vqn)
+
+    def validate(self, builder):
+        preset = builder().device('cpu').env(self.env).build()
+        # normal agent
+        agent = preset.agent(writer=DummyWriter(), train_steps=100000)
+        agent.act(self.env.state)
+        # test agent
+        test_agent = preset.test_agent()
+        test_agent.act(self.env.state)
+        # test save/load
+        preset.save('test_preset.pt')
+        preset = torch.load('test_preset.pt')
+        test_agent = preset.test_agent()
+        test_agent.act(self.env.state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/all/presets/continuous/__init__.py
+++ b/all/presets/continuous/__init__.py
@@ -1,6 +1,12 @@
 # from .actor_critic import actor_critic
-from .ddpg import ddpg
-from .ppo import ppo
+from .ddpg import ddpg, DDPGContinuousPreset
+from .ppo import ppo, PPOContinuousPreset
 from .sac import sac
 
-__all__ = ['ddpg', 'ppo', 'sac']
+__all__ = [
+    'ddpg',
+    'DDPGContinuousPreset',
+    'ppo',
+    'PPOContinuousPreset',
+    'sac',
+]

--- a/all/presets/continuous/ddpg.py
+++ b/all/presets/continuous/ddpg.py
@@ -1,42 +1,47 @@
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
-from all.agents import DDPG
+from all.agents import DDPG, DDPGTestAgent
 from all.approximation import QContinuous, PolyakTarget
 from all.bodies import TimeFeature
 from all.logging import DummyWriter
 from all.policies import DeterministicPolicy
 from all.memory import ExperienceReplayBuffer
 from .models import fc_q, fc_deterministic_policy
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ddpg(
-        # Common settings
-        device="cuda",
-        discount_factor=0.98,
-        last_frame=2e6,
-        # Adam optimizer settings
-        lr_q=1e-3,
-        lr_pi=1e-3,
-        # Training settings
-        minibatch_size=100,
-        update_frequency=1,
-        polyak_rate=0.005,
-        # Replay Buffer settings
-        replay_start_size=5000,
-        replay_buffer_size=1e6,
-        # Exploration settings
-        noise=0.1,
-        # Model construction
-        q_model_constructor=fc_q,
-        policy_model_constructor=fc_deterministic_policy
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.98,
+    # Adam optimizer settings
+    "lr_q": 1e-3,
+    "lr_pi": 1e-3,
+    # Training settings
+    "minibatch_size": 100,
+    "update_frequency": 1,
+    "polyak_rate": 0.005,
+    # Replay Buffer settings
+    "replay_start_size": 5000,
+    "replay_buffer_size": 1e6,
+    # Exploration settings
+    "noise": 0.1,
+    # Model construction
+    "q_model_constructor": fc_q,
+    "policy_model_constructor": fc_deterministic_policy
+}
+
+
+class DDPGContinuousPreset(Preset):
     """
     DDPG continuous control preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent..
+        env (all.environments.GymEnvironment): The classic control environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+    
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr_q (float): Learning rate for the Q network.
         lr_pi (float): Learning rate for the policy network.
         minibatch_size (int): Number of experiences to sample in each training update.
@@ -48,53 +53,67 @@ def ddpg(
         q_model_constructor (function): The function used to construct the neural q model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
-    def _ddpg(env, writer=DummyWriter()):
-        final_anneal_step = (last_frame - replay_start_size) // update_frequency
+    def __init__(self, env, device="cuda", **hyperparameters):
+        super().__init__()
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        self.q_model = hyperparameters["q_model_constructor"](env).to(device)
+        self.policy_model = hyperparameters["policy_model_constructor"](env).to(device)
+        self.hyperparameters = hyperparameters
+        self.device = device
+        self.action_space = env.action_space
 
-        q_model = q_model_constructor(env).to(device)
-        q_optimizer = Adam(q_model.parameters(), lr=lr_q)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = (train_steps - self.hyperparameters["replay_start_size"]) // self.hyperparameters["update_frequency"]
+
+        q_optimizer = Adam(self.q_model.parameters(), lr=self.hyperparameters["lr_q"])
+
         q = QContinuous(
-            q_model,
+            self.q_model,
             q_optimizer,
-            target=PolyakTarget(polyak_rate),
+            target=PolyakTarget(self.hyperparameters["polyak_rate"]),
             scheduler=CosineAnnealingLR(
                 q_optimizer,
-                final_anneal_step
+                n_updates
             ),
             writer=writer
         )
 
-        policy_model = policy_model_constructor(env).to(device)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr_pi)
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters["lr_pi"])
         policy = DeterministicPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
-            env.action_space,
-            target=PolyakTarget(polyak_rate),
+            self.action_space,
+            target=PolyakTarget(self.hyperparameters["polyak_rate"]),
             scheduler=CosineAnnealingLR(
                 policy_optimizer,
-                final_anneal_step
+                n_updates
             ),
             writer=writer
         )
 
         replay_buffer = ExperienceReplayBuffer(
-            replay_buffer_size,
-            device=device
+            self.hyperparameters["replay_buffer_size"],
+            device=self.device
         )
 
         return TimeFeature(DDPG(
             q,
             policy,
             replay_buffer,
-            env.action_space,
-            noise=noise,
-            replay_start_size=replay_start_size,
-            discount_factor=discount_factor,
-            update_frequency=update_frequency,
-            minibatch_size=minibatch_size,
+            self.action_space,
+            noise=self.hyperparameters["noise"],
+            replay_start_size=self.hyperparameters["replay_start_size"],
+            discount_factor=self.hyperparameters["discount_factor"],
+            update_frequency=self.hyperparameters["update_frequency"],
+            minibatch_size=self.hyperparameters["minibatch_size"],
         ))
-    return _ddpg
 
+    def test_agent(self):
+        policy = DeterministicPolicy(
+            self.policy_model,
+            None,
+            self.action_space,
+        )
+        return TimeFeature(DDPGTestAgent(policy))
 
-__all__ = ["ddpg"]
+ddpg = preset_builder('ddpg', default_hyperparameters, DDPGContinuousPreset)

--- a/all/presets/continuous/ddpg.py
+++ b/all/presets/continuous/ddpg.py
@@ -39,7 +39,7 @@ class DDPGContinuousPreset(Preset):
     Args:
         env (all.environments.GymEnvironment): The classic control environment for which to construct the agent.
         device (torch.device, optional): the device on which to load the agent
-    
+
     Keyword Args:
         discount_factor (float): Discount factor for future rewards.
         lr_q (float): Learning rate for the Q network.
@@ -53,6 +53,7 @@ class DDPGContinuousPreset(Preset):
         q_model_constructor (function): The function used to construct the neural q model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -115,5 +116,6 @@ class DDPGContinuousPreset(Preset):
             self.action_space,
         )
         return TimeFeature(DDPGTestAgent(policy))
+
 
 ddpg = preset_builder('ddpg', default_hyperparameters, DDPGContinuousPreset)

--- a/all/presets/continuous/ddpg.py
+++ b/all/presets/continuous/ddpg.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.agents import DDPG, DDPGTestAgent
@@ -111,7 +112,7 @@ class DDPGContinuousPreset(Preset):
 
     def test_agent(self):
         policy = DeterministicPolicy(
-            self.policy_model,
+            copy.deepcopy(self.policy_model),
             None,
             self.action_space,
         )

--- a/all/presets/continuous/ppo.py
+++ b/all/presets/continuous/ppo.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.agents import PPO, PPOTestAgent

--- a/all/presets/continuous/ppo.py
+++ b/all/presets/continuous/ppo.py
@@ -137,8 +137,8 @@ class PPOContinuousPreset(Preset):
         ))
 
     def test_agent(self):
-        feature = FeatureNetwork(self.feature_model)
-        policy = GaussianPolicy(self.policy_model, space=self.action_space)
+        feature = FeatureNetwork(copy.deepcopy(self.feature_model))
+        policy = GaussianPolicy(copy.deepcopy(self.policy_model), space=self.action_space)
         return TimeFeature(PPOTestAgent(feature, policy))
 
 

--- a/all/presets/continuous/ppo.py
+++ b/all/presets/continuous/ppo.py
@@ -60,6 +60,7 @@ class PPOContinuousPreset(Preset):
         lam (float): The Generalized Advantage Estimate (GAE) decay parameter.
         ac_model_constructor (function): The function used to construct the neural feature, value and policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(hyperparameters["n_envs"])

--- a/all/presets/continuous/ppo.py
+++ b/all/presets/continuous/ppo.py
@@ -1,46 +1,51 @@
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
-from all.agents import PPO
+from all.agents import PPO, PPOTestAgent
 from all.approximation import VNetwork, FeatureNetwork
 from all.bodies import TimeFeature
 from all.logging import DummyWriter
 from all.optim import LinearScheduler
 from all.policies import GaussianPolicy
 from .models import fc_actor_critic
+from ..builder import preset_builder
+from ..preset import Preset
 
 
-def ppo(
-        # Common settings
-        device="cuda",
-        discount_factor=0.98,
-        last_frame=2e6,
-        # Adam optimizer settings
-        lr=3e-4,  # Adam learning rate
-        eps=1e-5,  # Adam stability
-        # Loss scaling
-        entropy_loss_scaling=0.01,
-        value_loss_scaling=0.5,
-        # Training settings
-        clip_grad=0.5,
-        clip_initial=0.2,
-        clip_final=0.01,
-        epochs=20,
-        minibatches=4,
-        # Batch settings
-        n_envs=32,
-        n_steps=128,
-        # GAE settings
-        lam=0.95,
-        # Model construction
-        ac_model_constructor=fc_actor_critic
-):
+default_hyperparameters = {
+    # Common settings
+    "discount_factor": 0.98,
+    # Adam optimizer settings
+    "lr": 3e-4,  # Adam learning rate
+    "eps": 1e-5,  # Adam stability
+    # Loss scaling
+    "entropy_loss_scaling": 0.01,
+    "value_loss_scaling": 0.5,
+    # Training settings
+    "clip_grad": 0.5,
+    "clip_initial": 0.2,
+    "clip_final": 0.01,
+    "epochs": 20,
+    "minibatches": 4,
+    # Batch settings
+    "n_envs": 32,
+    "n_steps": 128,
+    # GAE settings
+    "lam": 0.95,
+    # Model construction
+    "ac_model_constructor": fc_actor_critic
+}
+
+
+class PPOContinuousPreset(Preset):
     """
-    PPO continuous control preset.
+    Proximal Policy Optimization (PPO) Continuous Control Preset.
 
     Args:
-        device (str): The device to load parameters and buffers onto for this agent.
+        env (all.environments.GymEnvironment): The classic control environment for which to construct the agent.
+        device (torch.device, optional): the device on which to load the agent
+
+    Keyword Args:
         discount_factor (float): Discount factor for future rewards.
-        last_frame (int): Number of frames to train.
         lr (float): Learning rate for the Adam optimizer.
         eps (float): Stability parameters for the Adam optimizer.
         entropy_loss_scaling (float): Coefficient for the entropy term in the total loss.
@@ -55,51 +60,56 @@ def ppo(
         lam (float): The Generalized Advantage Estimate (GAE) decay parameter.
         ac_model_constructor (function): The function used to construct the neural feature, value and policy model.
     """
-    def _ppo(envs, writer=DummyWriter()):
-        final_anneal_step = last_frame * epochs * minibatches / (n_steps * n_envs)
-        env = envs[0]
+    def __init__(self, env, device="cuda", **hyperparameters):
+        hyperparameters = {**default_hyperparameters, **hyperparameters}
+        super().__init__(hyperparameters["n_envs"])
+        feature_model, value_model, policy_model = hyperparameters["ac_model_constructor"](env)
+        self.feature_model = feature_model.to(device)
+        self.value_model = value_model.to(device)
+        self.policy_model = policy_model.to(device)
+        self.device = device
+        self.action_space = env.action_space
+        self.hyperparameters = hyperparameters
 
-        feature_model, value_model, policy_model = ac_model_constructor(env)
-        feature_model.to(device)
-        value_model.to(device)
-        policy_model.to(device)
+    def agent(self, writer=DummyWriter(), train_steps=float('inf')):
+        n_updates = train_steps * self.hyperparameters['epochs'] * self.hyperparameters['minibatches'] / (self.hyperparameters['n_steps'] * self.hyperparameters['n_envs'])
 
-        feature_optimizer = Adam(
-            feature_model.parameters(), lr=lr, eps=eps
-        )
-        value_optimizer = Adam(value_model.parameters(), lr=lr, eps=eps)
-        policy_optimizer = Adam(policy_model.parameters(), lr=lr, eps=eps)
+        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
+        value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
+        policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
 
         features = FeatureNetwork(
-            feature_model,
+            self.feature_model,
             feature_optimizer,
-            clip_grad=clip_grad,
+            clip_grad=self.hyperparameters['clip_grad'],
             scheduler=CosineAnnealingLR(
                 feature_optimizer,
-                final_anneal_step
+                n_updates
             ),
             writer=writer
         )
+
         v = VNetwork(
-            value_model,
+            self.value_model,
             value_optimizer,
-            loss_scaling=value_loss_scaling,
-            clip_grad=clip_grad,
+            loss_scaling=self.hyperparameters['value_loss_scaling'],
+            clip_grad=self.hyperparameters['clip_grad'],
             writer=writer,
             scheduler=CosineAnnealingLR(
                 value_optimizer,
-                final_anneal_step
+                n_updates
             ),
         )
+
         policy = GaussianPolicy(
-            policy_model,
+            self.policy_model,
             policy_optimizer,
-            env.action_space,
-            clip_grad=clip_grad,
+            self.action_space,
+            clip_grad=self.hyperparameters['clip_grad'],
             writer=writer,
             scheduler=CosineAnnealingLR(
                 policy_optimizer,
-                final_anneal_step
+                n_updates
             ),
         )
 
@@ -108,24 +118,27 @@ def ppo(
             v,
             policy,
             epsilon=LinearScheduler(
-                clip_initial,
-                clip_final,
+                self.hyperparameters['clip_initial'],
+                self.hyperparameters['clip_final'],
                 0,
-                final_anneal_step,
+                n_updates,
                 name='clip',
                 writer=writer
             ),
-            epochs=epochs,
-            minibatches=minibatches,
-            n_envs=n_envs,
-            n_steps=n_steps,
-            discount_factor=discount_factor,
-            lam=lam,
-            entropy_loss_scaling=entropy_loss_scaling,
+            epochs=self.hyperparameters['epochs'],
+            minibatches=self.hyperparameters['minibatches'],
+            n_envs=self.hyperparameters['n_envs'],
+            n_steps=self.hyperparameters['n_steps'],
+            discount_factor=self.hyperparameters['discount_factor'],
+            lam=self.hyperparameters['lam'],
+            entropy_loss_scaling=self.hyperparameters['entropy_loss_scaling'],
             writer=writer,
         ))
 
-    return _ppo, n_envs
+    def test_agent(self):
+        feature = FeatureNetwork(self.feature_model)
+        policy = GaussianPolicy(self.policy_model, space=self.action_space)
+        return TimeFeature(PPOTestAgent(feature, policy))
 
 
-__all__ = ["ppo"]
+ppo = preset_builder('ppo', default_hyperparameters, PPOContinuousPreset)

--- a/all/presets/continuous/sac.py
+++ b/all/presets/continuous/sac.py
@@ -1,3 +1,4 @@
+import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.agents import SAC, SACTestAgent

--- a/all/presets/continuous/sac.py
+++ b/all/presets/continuous/sac.py
@@ -64,6 +64,7 @@ class SACContinuousPreset(Preset):
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
     def __init__(self, env, device="cuda", **hyperparameters):
+        super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         self.q_1_model = hyperparameters["q1_model_constructor"](env).to(device)
         self.q_2_model = hyperparameters["q2_model_constructor"](env).to(device)

--- a/all/presets/continuous/sac.py
+++ b/all/presets/continuous/sac.py
@@ -148,7 +148,7 @@ class SACContinuousPreset(Preset):
         ))
 
     def test_agent(self):
-        policy = SoftDeterministicPolicy(self.policy_model, space=self.action_space)
+        policy = SoftDeterministicPolicy(copy.deepcopy(self.policy_model), space=self.action_space)
         return TimeFeature(SACTestAgent(policy))
 
 

--- a/all/presets/continuous/sac.py
+++ b/all/presets/continuous/sac.py
@@ -37,7 +37,6 @@ default_hyperparameters = {
 }
 
 
-
 class SACContinuousPreset(Preset):
     """
     Soft Actor-Critic (SAC) continuous control preset.
@@ -63,6 +62,7 @@ class SACContinuousPreset(Preset):
         v_model_constructor (function): The function used to construct the neural v model.
         policy_model_constructor (function): The function used to construct the neural policy model.
     """
+
     def __init__(self, env, device="cuda", **hyperparameters):
         super().__init__()
         hyperparameters = {**default_hyperparameters, **hyperparameters}
@@ -150,5 +150,6 @@ class SACContinuousPreset(Preset):
     def test_agent(self):
         policy = SoftDeterministicPolicy(self.policy_model, space=self.action_space)
         return TimeFeature(SACTestAgent(policy))
+
 
 sac = preset_builder('sac', default_hyperparameters, SACContinuousPreset)

--- a/all/presets/continuous_test.py
+++ b/all/presets/continuous_test.py
@@ -3,58 +3,30 @@ import unittest
 import torch
 from all.environments import GymEnvironment
 from all.logging import DummyWriter
-from all.presets.classic_control import (
-    a2c,
-    c51,
-    ddqn,
-    dqn,
+from all.presets.continuous import (
+    ddpg,
     ppo,
-    rainbow,
-    vac,
-    vpg,
-    vqn,
-    vsarsa,
+    sac,
 )
 
 
-class TestClassicControlPresets(unittest.TestCase):
+class TestContinuousPresets(unittest.TestCase):
     def setUp(self):
-        self.env = GymEnvironment('CartPole-v0')
+        self.env = GymEnvironment('LunarLanderContinuous-v2')
         self.env.reset()
 
     def tearDown(self):
         if os.path.exists('test_preset.pt'):
             os.remove('test_preset.pt')
 
-    def test_a2c(self):
-        self.validate(a2c)
-
-    def test_c51(self):
-        self.validate(c51)
-
-    def test_ddqn(self):
-        self.validate(ddqn)
-
-    def test_dqn(self):
-        self.validate(dqn)
+    def test_ddpg(self):
+        self.validate(ddpg)
 
     def test_ppo(self):
         self.validate(ppo)
 
-    def test_rainbow(self):
-        self.validate(rainbow)
-
-    def test_vac(self):
-        self.validate(vac)
-
-    def test_vpg(self):
-        self.validate(vpg)
-
-    def test_vsarsa(self):
-        self.validate(vsarsa)
-
-    def test_vqn(self):
-        self.validate(vqn)
+    def test_sac(self):
+        self.validate(sac)
 
     def validate(self, builder):
         preset = builder().device('cpu').env(self.env).build()

--- a/all/presets/continuous_test.py
+++ b/all/presets/continuous_test.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import torch
+from all.core import State
 from all.environments import GymEnvironment
 from all.logging import DummyWriter
 from all.presets.continuous import (

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -13,9 +13,9 @@ class Preset(ABC):
     Attributes:
         n_envs: If the Preset is for a ParallelAgent, the number of parallel environments.
     """
+
     def __init__(self, n_envs=None):
         self.n_envs = n_envs
-
 
     @abstractmethod
     def agent(self, writer=None, train_steps=float('inf')):
@@ -41,19 +41,17 @@ class Preset(ABC):
         """
         pass
 
-
     def save(self, filename):
         """
         Save the preset and the contained model to disk.
 
         The preset can later be loaded using torch.load(filename), allowing
         a test mode agent to be instansiated for evaluation or other purposes.
-        
+
         Args:
             filename (str): The path where the preset should be saved.
         """
         return torch.save(self, filename)
-
 
     def is_parallel(self):
         """

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -14,7 +14,6 @@ class Preset(ABC):
         n_envs: If the Preset is for a ParallelAgent, the number of parallel environments.
     """
     def __init__(self, n_envs=None):
-        super().__init__()
         self.n_envs = n_envs
 
 

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -3,21 +3,53 @@ import torch
 from torch.nn import Module
 
 
-class Preset(ABC, Module):
+class Preset(ABC):
+    """
+    A Preset agent configuration.
+
+    Args:
+        n_envs (int, optional): If the Preset is for a ParallelAgent,
+            sets the number of parallel environments.
+
+    Attributes:
+        n_envs: If the Preset is for a ParallelAgent, the number of parallel environments.
+    """
     def __init__(self, n_envs=None):
         super().__init__()
         self.n_envs = n_envs
 
+    """
+    Instansiate a training-mode agent with the existing model.
+
+    Args:
+        writer (all.logging.Writer, optional): Coefficient for the entropy term in the total loss.
+        train_steps (int, optional): The number of steps for which the agent will be trained.
+    """
     @abstractmethod
-    def agent(self, writer=None):
+    def agent(self, writer=None, train_steps=float('inf')):
         pass
 
+    """
+    Instansiate a test-mode agent with the existing model.
+    """
     @abstractmethod
-    def test_agent(self, writer=None):
+    def test_agent(self):
         pass
 
+    """
+    Save the preset and the contained model to disk.
+
+    The preset can later be loaded using torch.load(filename), allowing
+    a test mode agent to be instansiated for evaluation or other purposes.
+    
+    Args:
+        filename (str): The path where the preset should be saved.
+    """
     def save(self, filename):
         return torch.save(self, filename)
 
+    """
+    True if the Preset is for a parallel Agent, false otherwise.
+    """
     def is_parallel(self):
         return self.n_envs is not None

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from torch.nn import Module
+
+
+class Preset(ABC, Module):
+    @abstractmethod
+    def agent(self, writer=None):
+        pass
+
+    @abstractmethod
+    def test_agent(self, writer=None):
+        pass
+
+    def save(self, filename):
+        return torch.save(self, filename)

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -1,8 +1,13 @@
 from abc import ABC, abstractmethod
+import torch
 from torch.nn import Module
 
 
 class Preset(ABC, Module):
+    def __init__(self, n_envs=None):
+        super().__init__()
+        self.n_envs = n_envs
+
     @abstractmethod
     def agent(self, writer=None):
         pass
@@ -13,3 +18,6 @@ class Preset(ABC, Module):
 
     def save(self, filename):
         return torch.save(self, filename)
+
+    def is_parallel(self):
+        return self.n_envs is not None

--- a/all/presets/preset.py
+++ b/all/presets/preset.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import torch
-from torch.nn import Module
 
 
 class Preset(ABC):
@@ -18,38 +17,50 @@ class Preset(ABC):
         super().__init__()
         self.n_envs = n_envs
 
-    """
-    Instansiate a training-mode agent with the existing model.
 
-    Args:
-        writer (all.logging.Writer, optional): Coefficient for the entropy term in the total loss.
-        train_steps (int, optional): The number of steps for which the agent will be trained.
-    """
     @abstractmethod
     def agent(self, writer=None, train_steps=float('inf')):
+        """
+        Instansiate a training-mode agent with the existing model.
+
+        Args:
+            writer (all.logging.Writer, optional): Coefficient for the entropy term in the total loss.
+            train_steps (int, optional): The number of steps for which the agent will be trained.
+
+        Returns:
+            all.agents.Agent: The instansiated Agent.
+        """
         pass
 
-    """
-    Instansiate a test-mode agent with the existing model.
-    """
     @abstractmethod
     def test_agent(self):
+        """
+        Instansiate a test-mode agent with the existing model.
+
+        Returns:
+            all.agents.Agent: The instansiated test Agent.
+        """
         pass
 
-    """
-    Save the preset and the contained model to disk.
 
-    The preset can later be loaded using torch.load(filename), allowing
-    a test mode agent to be instansiated for evaluation or other purposes.
-    
-    Args:
-        filename (str): The path where the preset should be saved.
-    """
     def save(self, filename):
+        """
+        Save the preset and the contained model to disk.
+
+        The preset can later be loaded using torch.load(filename), allowing
+        a test mode agent to be instansiated for evaluation or other purposes.
+        
+        Args:
+            filename (str): The path where the preset should be saved.
+        """
         return torch.save(self, filename)
 
-    """
-    True if the Preset is for a parallel Agent, false otherwise.
-    """
+
     def is_parallel(self):
+        """
+        Determine whether the Preset is for a parallel Agent.
+
+        Returns:
+            bool: True if the Preset is for a parallel Agent, False otherwise.
+        """
         return self.n_envs is not None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Chris Nota'
 author = 'Chris Nota'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.3'
+release = '0.6.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,7 @@ Enjoy!
     guide/benchmark_performance
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 4
     :caption: Modules:
 
     modules/agents

--- a/docs/source/modules/presets.rst
+++ b/docs/source/modules/presets.rst
@@ -2,9 +2,12 @@ all.presets
 ===========
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
     :caption: all.presets
 
     presets/atari
     presets/classic
     presets/continuous
+
+.. automodule:: all.presets
+    :members:

--- a/docs/source/modules/presets/atari.rst
+++ b/docs/source/modules/presets/atari.rst
@@ -8,4 +8,5 @@ all.presets.atari
 
 .. automodule:: all.presets.atari
     :members:
-    
+    :inherited-members:
+    :show-inheritance:

--- a/docs/source/modules/presets/classic.rst
+++ b/docs/source/modules/presets/classic.rst
@@ -8,3 +8,4 @@ all.presets.classic_control
 
 .. automodule:: all.presets.classic_control
     :members:
+    :inherited-members:

--- a/docs/source/modules/presets/continuous.rst
+++ b/docs/source/modules/presets/continuous.rst
@@ -8,3 +8,4 @@ all.presets.continuous
 
 .. automodule:: all.presets.continuous
     :members:
+    :inherited-members:

--- a/integration/atari_test.py
+++ b/integration/atari_test.py
@@ -43,52 +43,52 @@ class TestAtariPresets(unittest.TestCase):
 
     def test_ddqn(self):
         validate_agent(
-            ddqn(replay_start_size=64, device=CPU),
+            ddqn(device=CPU),
             AtariEnvironment("Breakout", device=CPU),
         )
 
     def test_ddqn_cuda(self):
         validate_agent(
-            ddqn(replay_start_size=64, device=CUDA),
+            ddqn(device=CUDA).hyperparameters(replay_start_size=64),
             AtariEnvironment("Breakout", device=CUDA),
         )
 
     def test_dqn(self):
         validate_agent(
-            dqn(replay_start_size=64, device=CPU),
+            dqn(device=CPU).hyperparameters(replay_start_size=64),
             AtariEnvironment("Breakout", device=CPU),
         )
 
     def test_dqn_cuda(self):
         validate_agent(
-            dqn(replay_start_size=64, device=CUDA),
+            dqn(device=CUDA).hyperparameters(replay_start_size=64),
             AtariEnvironment("Breakout", device=CUDA),
         )
 
     def test_ppo(self):
-        validate_agent(ppo(device=CPU, n_envs=4), AtariEnvironment("Breakout", device=CPU))
+        validate_agent(ppo(device=CPU).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CPU))
 
     def test_ppo_cuda(self):
-        validate_agent(ppo(device=CUDA, n_envs=4), AtariEnvironment("Breakout", device=CUDA))
+        validate_agent(ppo(device=CUDA).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CUDA))
 
     def test_rainbow(self):
         validate_agent(
-            rainbow(replay_start_size=64, device=CPU),
+            rainbow(device=CPU).hyperparameters(replay_start_size=64),
             AtariEnvironment("Breakout", device=CPU),
         )
 
     def test_rainbow_cuda(self):
         validate_agent(
-            rainbow(replay_start_size=64, device=CUDA),
+            rainbow(device=CUDA).hyperparameters(replay_start_size=64),
             AtariEnvironment("Breakout", device=CUDA),
         )
 
     def test_vac(self):
-        validate_agent(vac(device=CPU, n_envs=4), AtariEnvironment("Breakout", device=CPU))
+        validate_agent(vac(device=CPU).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CPU))
 
     def test_vac_cuda(self):
         validate_agent(
-            vac(device=CUDA, n_envs=4), AtariEnvironment("Breakout", device=CUDA)
+            vac(device=CUDA).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CUDA)
         )
 
     def test_vpg(self):
@@ -100,19 +100,19 @@ class TestAtariPresets(unittest.TestCase):
         )
 
     def test_vsarsa(self):
-        validate_agent(vsarsa(device=CPU, n_envs=4), AtariEnvironment("Breakout", device=CPU))
+        validate_agent(vsarsa(device=CPU).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CPU))
 
     def test_vsarsa_cuda(self):
         validate_agent(
-            vsarsa(device=CUDA, n_envs=4), AtariEnvironment("Breakout", device=CUDA)
+            vsarsa(device=CUDA).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CUDA)
         )
 
     def test_vqn(self):
-        validate_agent(vqn(device=CPU, n_envs=4), AtariEnvironment("Breakout", device=CPU))
+        validate_agent(vqn(device=CPU).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CPU))
 
     def test_vqn_cuda(self):
         validate_agent(
-            vqn(device=CUDA, n_envs=4), AtariEnvironment("Breakout", device=CUDA)
+            vqn(device=CUDA).hyperparameters(n_envs=4), AtariEnvironment("Breakout", device=CUDA)
         )
 
 

--- a/integration/classic_control_test.py
+++ b/integration/classic_control_test.py
@@ -46,8 +46,8 @@ class TestClassicControlPresets(unittest.TestCase):
     def test_vqn(self):
         self.validate(vqn())
 
-    def validate(self, make_agent):
-        validate_agent(make_agent, GymEnvironment("CartPole-v0"))
+    def validate(self, builder):
+        validate_agent(builder.device('cpu'), GymEnvironment("CartPole-v0"))
 
 
 if __name__ == "__main__":

--- a/integration/continuous_test.py
+++ b/integration/continuous_test.py
@@ -6,20 +6,22 @@ from validate_agent import validate_agent
 
 class TestContinuousPresets(unittest.TestCase):
     def test_ddpg(self):
-        self.validate(ddpg(replay_start_size=50, device='cpu'))
+        validate_agent(
+            ddpg().device('cpu').hyperparameters(replay_start_size=50),
+            GymEnvironment('LunarLanderContinuous-v2')
+        )
 
     def test_ppo(self):
-        self.validate(ppo(n_envs=4, n_steps=4, epochs=4, minibatches=4, device='cpu'))
+        validate_agent(
+            ppo().device('cpu'),
+            GymEnvironment('LunarLanderContinuous-v2')
+        )
 
     def test_sac(self):
         validate_agent(
             sac().device('cpu').hyperparameters(replay_start_size=50),
             GymEnvironment('LunarLanderContinuous-v2')
         )
-
-    def validate(self, make_agent):
-        validate_agent(make_agent, GymEnvironment('LunarLanderContinuous-v2'))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/integration/continuous_test.py
+++ b/integration/continuous_test.py
@@ -23,5 +23,6 @@ class TestContinuousPresets(unittest.TestCase):
             GymEnvironment('LunarLanderContinuous-v2')
         )
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/integration/continuous_test.py
+++ b/integration/continuous_test.py
@@ -12,7 +12,10 @@ class TestContinuousPresets(unittest.TestCase):
         self.validate(ppo(n_envs=4, n_steps=4, epochs=4, minibatches=4, device='cpu'))
 
     def test_sac(self):
-        self.validate(sac(replay_start_size=50, device='cpu'))
+        validate_agent(
+            sac().device('cpu').hyperparameters(replay_start_size=50),
+            GymEnvironment('LunarLanderContinuous-v2')
+        )
 
     def validate(self, make_agent):
         validate_agent(make_agent, GymEnvironment('LunarLanderContinuous-v2'))

--- a/integration/validate_agent.py
+++ b/integration/validate_agent.py
@@ -16,9 +16,10 @@ class TestParallelEnvExperiment(ParallelEnvExperiment):
 
 
 def validate_agent(agent, env):
-    if isinstance(agent, tuple):
-        experiment = TestParallelEnvExperiment(agent, env, quiet=True)
+    preset = agent.env(env).build()
+    if preset.is_parallel():
+        experiment = TestParallelEnvExperiment(preset, env, quiet=True)
     else:
-        experiment = TestSingleEnvExperiment(agent, env, quiet=True)
+        experiment = TestSingleEnvExperiment(preset, env, quiet=True)
     experiment.train(episodes=2)
     experiment.test(episodes=2)

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -19,7 +19,7 @@ def main():
         "--frames", type=int, default=40e6, help="The number of training frames."
     )
     parser.add_argument(
-        "--render", type=bool, default=False, help="Render the environment."
+        "--render", action="store_true", default=False, help="Render the environment."
     )
     parser.add_argument(
         "--logdir", default='runs', help="The base logging directory."

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -24,12 +24,20 @@ def main():
     parser.add_argument(
         "--logdir", default='runs', help="The base logging directory."
     )
+    parser.add_argument('--hyperparameters', nargs='*')
     args = parser.parse_args()
 
     env = AtariEnvironment(args.env, device=args.device)
     agent_name = args.agent
     agent = getattr(atari, agent_name)
     agent = agent().device(args.device)
+
+    # parse hyperparameters
+    hyperparameters = {}
+    for hp in args.hyperparameters:
+        key, value = hp.split('=')
+        hyperparameters[key] = type(agent._hyperparameters[key])(value)
+    agent = agent.hyperparameters(**hyperparameters)
 
     run_experiment(
         agent,

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -29,9 +29,10 @@ def main():
     env = AtariEnvironment(args.env, device=args.device)
     agent_name = args.agent
     agent = getattr(atari, agent_name)
+    agent = agent().device(args.device)
 
     run_experiment(
-        agent(device=args.device, last_frame=args.frames),
+        agent,
         env,
         args.frames,
         render=args.render,

--- a/scripts/atari.py
+++ b/scripts/atari.py
@@ -24,7 +24,7 @@ def main():
     parser.add_argument(
         "--logdir", default='runs', help="The base logging directory."
     )
-    parser.add_argument('--hyperparameters', nargs='*')
+    parser.add_argument('--hyperparameters', default=[], nargs='*')
     args = parser.parse_args()
 
     env = AtariEnvironment(args.env, device=args.device)

--- a/scripts/classic.py
+++ b/scripts/classic.py
@@ -19,7 +19,7 @@ def main():
         "--frames", type=int, default=20000, help="The number of training frames."
     )
     parser.add_argument(
-        "--render", type=bool, default=False, help="Render the environment."
+        "--render", action="store_true", default=False, help="Render the environment."
     )
     parser.add_argument(
         "--logdir", default='runs', help="The base logging directory."

--- a/scripts/continuous.py
+++ b/scripts/continuous.py
@@ -36,7 +36,7 @@ def main():
         "--frames", type=int, default=2e6, help="The number of training frames."
     )
     parser.add_argument(
-        "--render", type=bool, default=False, help="Render the environment."
+        "--render", action="store_true", default=False, help="Render the environment."
     )
     parser.add_argument(
         "--logdir", default='runs', help="The base logging directory."

--- a/scripts/watch_atari.py
+++ b/scripts/watch_atari.py
@@ -1,16 +1,16 @@
 import argparse
 from all.bodies import DeepmindAtariBody
 from all.environments import AtariEnvironment
-from all.experiments import GreedyAgent, watch
+from all.experiments import load_and_watch
 
 
 def main():
     parser = argparse.ArgumentParser(description="Run an Atari benchmark.")
     parser.add_argument("env", help="Name of the Atari game (e.g. Pong)")
-    parser.add_argument("dir", help="Directory where the agent's model was saved.")
+    parser.add_argument("filename", help="File where the model was saved.")
     parser.add_argument(
         "--device",
-        default="cpu",
+        default="cuda",
         help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
     )
     parser.add_argument(
@@ -20,8 +20,7 @@ def main():
     )
     args = parser.parse_args()
     env = AtariEnvironment(args.env, device=args.device)
-    agent = DeepmindAtariBody(GreedyAgent.load(args.dir, env))
-    watch(agent, env, fps=args.fps)
+    load_and_watch(args.filename, env, fps=args.fps)
 
 
 if __name__ == "__main__":

--- a/scripts/watch_classic.py
+++ b/scripts/watch_classic.py
@@ -6,15 +6,20 @@ from all.experiments import load_and_watch
 def main():
     parser = argparse.ArgumentParser(description="Run an Atari benchmark.")
     parser.add_argument("env", help="Name of the environment (e.g. RoboschoolHalfCheetah-v1")
-    parser.add_argument("dir", help="Directory where the agent's model was saved.")
+    parser.add_argument("filename", help="File where the model was saved.")
     parser.add_argument(
         "--device",
-        default="cpu",
+        default="cuda",
         help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
+    )
+    parser.add_argument(
+        "--fps",
+        default=60,
+        help="Playback speed",
     )
     args = parser.parse_args()
     env = GymEnvironment(args.env, device=args.device)
-    load_and_watch(args.dir, env)
+    load_and_watch(args.filename, env, fps=args.fps)
 
 
 if __name__ == "__main__":

--- a/scripts/watch_continuous.py
+++ b/scripts/watch_continuous.py
@@ -4,17 +4,17 @@ import pybullet
 import pybullet_envs
 from all.bodies import TimeFeature
 from all.environments import GymEnvironment
-from all.experiments import GreedyAgent, watch
-from continuous import ENVS
+from all.experiments import load_and_watch
+from .continuous import ENVS
 
 
 def main():
     parser = argparse.ArgumentParser(description="Watch a continuous agent.")
     parser.add_argument("env", help="ID of the Environment")
-    parser.add_argument("dir", help="Directory where the agent's model was saved.")
+    parser.add_argument("filename", help="File where the model was saved.")
     parser.add_argument(
         "--device",
-        default="cpu",
+        default="cuda",
         help="The name of the device to run the agent on (e.g. cpu, cuda, cuda:0)",
     )
     parser.add_argument(
@@ -30,8 +30,7 @@ def main():
         env_id = args.env
 
     env = GymEnvironment(env_id, device=args.device)
-    agent = TimeFeature(GreedyAgent.load(args.dir, env))
-    watch(agent, env, fps=args.fps)
+    load_and_watch(args.filename, env, fps=args.fps)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It's here! This PR dds the ability to save/load agents, addressing #161 .

There are a few keys to the design. First of all, rather than having `agent.act(state)` and `agent.eval(state)`, agents were split into a training-mode `Agent` and a `TestAgent`.  Both types of agents can be instantiated by a `Preset`:

```python
agent = preset.agent()
test_agent = preset.test_agent()
```

The `Preset` is a serializable object containing the hyperparameters and all necessary `torch` models. The `TestAgent` inherits a copy of the model trained by the `Agent`, allowing `TestAgent`s from different points in training to be stored.

The second major key to the design is that the `Preset`, rather than the `Agent` itself is saved:

```python
preset.save(filename)
preset = torch.load(filename)
```
This is important because the underlying `Agent` objects are often difficult to serialize, and even if they can be serialized they can take up an excessive amount of storage (for example, a standard 1 million frame Atari replay buffer is ~7 GB).

One thing to note is that while this design supports creating a training mode `Agent` with a previously trained network, it does not support a full "resume" of training, e.g., scheduler states will be reset and replay buffers will be cleared. Full resume functionality introduces many difficulties which interfere with the design of the library, however, we may implement a partial solution in the future.

Example usage can be found below:

```python
# construct the preset
preset = builder().hyperparameters(lr=1e-3).env(some_env).build()

# run agent in train mode
agent = preset.agent()
for i in range(episodes)
    run_episode(agent, some_env)

# run agent in test mode
test_agent = preset.test_agent()
for i in range(test_episodes)
    run_episode(test_agent, some_env)

# save the model for later
preset.save('dqn.pt')

# load model from disk and watch
preset = torch.load('dqn.pt')
test_agent = preset.test_agent()
for i in range(test_episodes)
    run_episode(test_agent, some_env, render=True)
```