### PR TITLE
Feature/cpu replay buffer

### DIFF
--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -9,6 +9,7 @@ class FrameStack(Body):
         self._frames = []
         self._size = size
         self._lazy = lazy
+        self._to_cache = ToCache()
 
     def process_state(self, state):
         if not self._frames:
@@ -16,16 +17,47 @@ class FrameStack(Body):
         else:
             self._frames = self._frames[1:] + [state.observation]
         if self._lazy:
-            return LazyState.from_state(state, self._frames)
+            return LazyState.from_state(state, self._frames, self._to_cache)
         if isinstance(state, StateArray):
             return state.update('observation', torch.cat(self._frames, dim=1))
         return state.update('observation', torch.cat(self._frames, dim=0))
 
 
+class ToCache:
+    def __init__(self, from_device=None, to_device=None, max_size=16):
+        self.from_device = from_device
+        self.to_device = to_device
+        self.max_size = max_size
+        self.cache_data = []
+
+    def convert(self, value, device):
+        if self.from_device is None:
+            self.from_device = value.device
+        if self.to_device is None:
+            self.to_device = device
+        if self.from_device != value.device or self.to_device != device:
+            raise ValueError("bad devices to convert lazystate, must be internally consistent")
+
+        cached = None
+        for el in self.cache_data:
+            if el[0] is value:
+                cached = el[1]
+                break
+        if cached is not None:
+            new_v = cached
+        else:
+            new_v = value.to(device)
+            self.cache_data.append((value, new_v))
+            if len(self.cache_data) > self.max_size:
+                self.cache_data.pop(0)
+        return new_v
+
+
 class LazyState(State):
     @classmethod
-    def from_state(cls, state, frames):
+    def from_state(cls, state, frames, to_cache):
         state = LazyState(state, device=state.device)
+        state.to_cache = to_cache
         state['observation'] = frames
         return state
 
@@ -36,3 +68,17 @@ class LazyState(State):
                 return v
             return torch.cat(dict.__getitem__(self, key), dim=0)
         return super().__getitem__(key)
+
+    def to(self, device):
+        if device == self.device:
+            return self
+        x = {}
+        for key, value in self.items():
+            if key == 'observation':
+                x[key] = [self.to_cache.convert(v, device) for v in value]
+                # x[key] = [v.to(device) for v in value]#torch.cat(value,axis=0).to(device)
+            elif torch.is_tensor(value):
+                x[key] = value.to(device)
+            else:
+                x[key] = value
+        return LazyState(x, device=device)

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -304,7 +304,7 @@ class StateArray(State):
         return tensor.view((*self.shape, *tensor.shape[1:]))
 
     def apply_mask(self, tensor):
-        return tensor * self.mask.unsqueeze(-1)  # pylint: disable=no-member
+        return tensor * self.mask.unsqueeze(-1)
 
     def flatten(self):
         """

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -31,7 +31,6 @@ class State(dict):
         device (string):
             The torch device on which component tensors are stored.
     """
-
     def __init__(self, x, device='cpu', **kwargs):
         if not isinstance(x, dict):
             x = {'observation': x}
@@ -68,11 +67,15 @@ class State(dict):
         for key in list_of_states[0].keys():
             v = list_of_states[0][key]
             try:
-                if torch.is_tensor(v):
+                if isinstance(v, list) and len(v) > 0 and torch.is_tensor(v[0]):
+                    x[key] = torch.stack([torch.stack(state[key]) for state in list_of_states])
+                elif torch.is_tensor(v):
                     x[key] = torch.stack([state[key] for state in list_of_states])
                 else:
                     x[key] = torch.tensor([state[key] for state in list_of_states], device=device)
-            except BaseException:
+            except ValueError:
+                pass
+            except KeyError:
                 pass
         return StateArray(x, shape, device=device)
 
@@ -188,6 +191,17 @@ class State(dict):
             x[key] = info[key]
         return State(x, device=device)
 
+    def to(self, device):
+        if device == self.device:
+            return self
+        x = {}
+        for key, value in self.items():
+            if torch.is_tensor(value):
+                x[key] = value.to(device)
+            else:
+                x[key] = value
+        return type(self)(x, device=device, shape=self._shape)
+
     @property
     def observation(self):
         """A tensor containing the current observation."""
@@ -246,7 +260,6 @@ class StateArray(State):
             device (string):
                 The torch device on which component tensors are stored.
     """
-
     def __init__(self, x, shape, device='cpu', **kwargs):
         if not isinstance(x, dict):
             x = {'observation': x}
@@ -291,7 +304,7 @@ class StateArray(State):
         return tensor.view((*self.shape, *tensor.shape[1:]))
 
     def apply_mask(self, tensor):
-        return tensor * self.mask.unsqueeze(-1)
+        return tensor * self.mask.unsqueeze(-1)  # pylint: disable=no-member
 
     def flatten(self):
         """
@@ -350,7 +363,7 @@ class StateArray(State):
             for (k, v) in self.items():
                 try:
                     d[k] = v[key]
-                except BaseException:
+                except KeyError:
                     pass
             return self.__class__(d, shape, device=self.device)
         try:

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -97,6 +97,13 @@ class StateTest(unittest.TestCase):
         self.assertEqual(output.shape, (5, 3))
         self.assertEqual(output.sum().item(), 0)
 
+    def test_to_device(self):
+        observation = torch.randn(3, 4)
+        state = State(observation,device=torch.device('cpu'))
+        state_cpu = state.to("cpu")
+        self.assertTrue(torch.equal(state['observation'], state_cpu['observation']))
+        self.assertFalse(state is state_cpu)
+
 
 class StateArrayTest(unittest.TestCase):
     def test_constructor_defaults(self):

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -99,7 +99,7 @@ class StateTest(unittest.TestCase):
 
     def test_to_device(self):
         observation = torch.randn(3, 4)
-        state = State(observation,device=torch.device('cpu'))
+        state = State(observation, device=torch.device('cpu'))
         state_cpu = state.to("cpu")
         self.assertTrue(torch.equal(state['observation'], state_cpu['observation']))
         self.assertFalse(state is state_cpu)

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -23,11 +23,13 @@ class ReplayBuffer(ABC):
 # Adapted from:
 # https://github.com/Shmuma/ptan/blob/master/ptan/experience.py
 class ExperienceReplayBuffer(ReplayBuffer):
-    def __init__(self, size, device='cpu', store_device='cpu'):
+    def __init__(self, size, device='cpu', store_device=None):
         self.buffer = []
         self.capacity = int(size)
         self.pos = 0
         self.device = torch.device(device)
+        if store_device is None:
+            store_device = self.device
         self.store_device = torch.device(store_device)
 
     def store(self, state, action, next_state):
@@ -74,9 +76,10 @@ class PrioritizedReplayBuffer(ExperienceReplayBuffer, Schedulable):
             alpha=0.6,
             beta=0.4,
             epsilon=1e-5,
-            device=torch.device('cpu')
+            device=torch.device('cpu'),
+            store_device=None
     ):
-        super().__init__(buffer_size, device=device)
+        super().__init__(buffer_size, device=device, store_device=store_device)
 
         assert alpha >= 0
         self._alpha = alpha


### PR DESCRIPTION
This gives the replay buffers a `store_device` parameter which allows it to store the replay buffer on a different device than it expects input and output to be. The main use case is if you want the replay buffer to be stored in CPU memory while the network and training lives in GPU memory. I measured the performance hit of doing this to be about 10-15% on DQN. 

Right now there is no parameter for `store_device` on the presets, though perhaps there should be.