### PR TITLE
Bugfix/state

### DIFF
--- a/all/bodies/atari.py
+++ b/all/bodies/atari.py
@@ -5,9 +5,10 @@ from .vision import FrameStack
 
 
 class DeepmindAtariBody(Body):
-    def __init__(self, agent, lazy_frames=False, episodic_lives=True, frame_stack=4):
+    def __init__(self, agent, lazy_frames=False, episodic_lives=True, frame_stack=4, clip_rewards=True):
         agent = FrameStack(agent, lazy=lazy_frames, size=frame_stack)
-        agent = ClipRewards(agent)
+        if clip_rewards:
+            agent = ClipRewards(agent)
         if episodic_lives:
             agent = EpisodicLives(agent)
         super().__init__(agent)

--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -28,6 +28,7 @@ class TensorDeviceCache:
     To efficiently implement device trasfer of lazy states, this class
     caches the transfered tensor so that it is not copied multiple times.
     '''
+
     def __init__(self, max_size=16):
         self.max_size = max_size
         self.cache_data = []

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -77,6 +77,8 @@ class State(dict):
                 pass
             except KeyError:
                 pass
+            except TypeError:
+                pass
         return StateArray(x, shape, device=device)
 
     def apply(self, model, *keys):

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -31,6 +31,7 @@ class State(dict):
         device (string):
             The torch device on which component tensors are stored.
     """
+
     def __init__(self, x, device='cpu', **kwargs):
         if not isinstance(x, dict):
             x = {'observation': x}
@@ -262,6 +263,7 @@ class StateArray(State):
             device (string):
                 The torch device on which component tensors are stored.
     """
+
     def __init__(self, x, shape, device='cpu', **kwargs):
         if not isinstance(x, dict):
             x = {'observation': x}

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -78,8 +78,6 @@ class State(dict):
                 pass
             except KeyError:
                 pass
-            except TypeError:
-                pass
         return StateArray(x, shape, device=device)
 
     def apply(self, model, *keys):

--- a/all/environments/atari.py
+++ b/all/environments/atari.py
@@ -7,6 +7,7 @@ from .atari_wrappers import (
     WarpFrame,
     LifeLostEnv,
 )
+from all.core import State
 
 
 class AtariEnvironment(GymEnvironment):
@@ -30,6 +31,11 @@ class AtariEnvironment(GymEnvironment):
     @property
     def name(self):
         return self._name
+
+    def reset(self):
+        state = self._env.reset(), 0., False, {'life_lost': False}
+        self._state = State.from_gym(state, dtype=self._env.observation_space.dtype, device=self._device)
+        return self._state
 
     def duplicate(self, n):
         return [

--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -41,7 +41,8 @@ class GymEnvironment(Environment):
         return self._name
 
     def reset(self):
-        self._state = State.from_gym(self._env.reset(), dtype=self._env.observation_space.dtype, device=self._device)
+        state = self._env.reset(), 0., False, None
+        self._state = State.from_gym(state, dtype=self._env.observation_space.dtype, device=self._device)
         return self._state
 
     def step(self, action):

--- a/all/memory/generalized_advantage.py
+++ b/all/memory/generalized_advantage.py
@@ -1,8 +1,9 @@
 import torch
 from all.core import State
+from all.optim import Schedulable
 
 
-class GeneralizedAdvantageBuffer:
+class GeneralizedAdvantageBuffer(Schedulable):
     def __init__(
             self,
             v,

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -151,6 +151,7 @@ class PrioritizedReplayBuffer(ExperienceReplayBuffer, Schedulable):
 
 class NStepReplayBuffer(ReplayBuffer):
     '''Converts any ReplayBuffer into an NStepReplayBuffer'''
+
     def __init__(
             self,
             steps,


### PR DESCRIPTION
Certain Atari environments were sometimes crashing because the the `info` object is not set when environments are reset, therefore, there is a `TypeError` raised. 

I also slipped in a couple of minor "features":
* The `GeneralizedAdvantageBuffer` is now a `Schedulable`, meaning components like lambda and gamma can be scheduled
* `clip_rewards` is now a toggleable feature in `DeepmindAtariBody`