### PR TITLE
Use cloudpickle for environment duplication

### DIFF
--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -2,6 +2,7 @@ import gym
 import torch
 from all.core import State
 from .abstract import Environment
+import cloudpickle
 gym.logger.set_level(40)
 
 
@@ -63,7 +64,7 @@ class GymEnvironment(Environment):
         self._env.seed(seed)
 
     def duplicate(self, n):
-        return [GymEnvironment(self._name, device=self.device) for _ in range(n)]
+        return [GymEnvironment(cloudpickle.loads(cloudpickle.dumps(self._env)), device=self.device) for _ in range(n)]
 
     @property
     def state_space(self):

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "torch~=1.5.1",            # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
+        "cloudpickle",             # used to copy environments
     ],
     extras_require=extras
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "torch~=1.5.1",            # core deep learning library
         "tensorboard>=2.3.0",      # logging and visualization
         "tensorboardX>=2.1.0",     # tensorboard/pytorch compatibility
-        "cloudpickle",             # used to copy environments
+        "cloudpickle>=1.2.0",      # used to copy environments
     ],
     extras_require=extras
 )


### PR DESCRIPTION
Right now the way environments are duplicated requires named gym environments. For third party gym environments without names, or supersuit wrapped gym environments, this doesn't function. The typical way to duplication in these cases is pickle or cloud pickle, and there's a few things we'd like to use this for that pickle can't handle. Also, gym depends on cloud pickle, so this isn't really adding a new dependency.