### PR TITLE
Feature/identity

### DIFF
--- a/all/approximation/__init__.py
+++ b/all/approximation/__init__.py
@@ -4,6 +4,7 @@ from .q_dist import QDist
 from .q_network import QNetwork
 from .v_network import VNetwork
 from .feature_network import FeatureNetwork
+from .identity import Identity
 from .target import TargetNetwork, FixedTarget, PolyakTarget, TrivialTarget
 from .checkpointer import Checkpointer, DummyCheckpointer, PeriodicCheckpointer
 
@@ -16,10 +17,11 @@ __all__ = [
     "VNetwork",
     "FeatureNetwork",
     "TargetNetwork",
+    "Identity",
     "FixedTarget",
     "PolyakTarget",
     "TrivialTarget",
     "Checkpointer",
     "DummyCheckpointer",
-    "PeriodicCheckpointer"
+    "PeriodicCheckpointer",
 ]

--- a/all/approximation/feature_network_test.py
+++ b/all/approximation/feature_network_test.py
@@ -62,8 +62,7 @@ class TestFeatureNetwork(unittest.TestCase):
 
     def test_identity_features(self):
         model = nn.Sequential(nn.Identity())
-        optimizer = torch.optim.SGD(self.model.parameters(), lr=0.1)
-        features = FeatureNetwork(model, optimizer, device='cpu')
+        features = FeatureNetwork(model, None, device='cpu')
 
         # forward pass
         x = State({'observation': torch.tensor([1., 2., 3.])})

--- a/all/approximation/identity.py
+++ b/all/approximation/identity.py
@@ -1,0 +1,20 @@
+import torch
+from torch import nn
+from .approximation import Approximation
+
+
+class Identity(Approximation):
+    '''
+    An Approximation that represents the identity function.
+
+    Because the model has no parameters, reinforce and step do nothing.
+    '''
+
+    def __init__(self, device, name='identity', **kwargs):
+        super().__init__(nn.Identity(), None, device=device, name=name, **kwargs)
+
+    def reinforce(self):
+        return self
+
+    def step(self):
+        return self

--- a/all/approximation/identity_test.py
+++ b/all/approximation/identity_test.py
@@ -15,9 +15,9 @@ class TestIdentityNetwork(unittest.TestCase):
         tt.assert_equal(inputs, outputs)
 
     def test_forward_state(self):
-        inputs = State({ 
+        inputs = State({
             'observation': torch.tensor([1, 2, 3])
-         })
+        })
         outputs = self.model(inputs)
         self.assertEqual(inputs, outputs)
 
@@ -30,7 +30,6 @@ class TestIdentityNetwork(unittest.TestCase):
         inputs = torch.tensor([1, 2, 3])
         outputs = self.model.target(inputs)
         tt.assert_equal(inputs, outputs)
-
 
     def test_reinforce(self):
         self.model.reinforce()

--- a/all/approximation/identity_test.py
+++ b/all/approximation/identity_test.py
@@ -1,0 +1,43 @@
+import unittest
+import torch
+import torch_testing as tt
+from all.core import State
+from all.approximation import Identity, FixedTarget
+
+
+class TestIdentityNetwork(unittest.TestCase):
+    def setUp(self):
+        self.model = Identity('cpu', target=FixedTarget(10))
+
+    def test_forward_tensor(self):
+        inputs = torch.tensor([1, 2, 3])
+        outputs = self.model(inputs)
+        tt.assert_equal(inputs, outputs)
+
+    def test_forward_state(self):
+        inputs = State({ 
+            'observation': torch.tensor([1, 2, 3])
+         })
+        outputs = self.model(inputs)
+        self.assertEqual(inputs, outputs)
+
+    def test_eval(self):
+        inputs = torch.tensor([1, 2, 3])
+        outputs = self.model.target(inputs)
+        tt.assert_equal(inputs, outputs)
+
+    def test_target(self):
+        inputs = torch.tensor([1, 2, 3])
+        outputs = self.model.target(inputs)
+        tt.assert_equal(inputs, outputs)
+
+
+    def test_reinforce(self):
+        self.model.reinforce()
+
+    def test_step(self):
+        self.model.step()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import warnings
 
 
 class State(dict):
@@ -65,6 +66,7 @@ class State(dict):
         device = list_of_states[0].device
         shape = (len(list_of_states), *list_of_states[0].shape)
         x = {}
+
         for key in list_of_states[0].keys():
             v = list_of_states[0][key]
             try:
@@ -74,10 +76,13 @@ class State(dict):
                     x[key] = torch.stack([state[key] for state in list_of_states])
                 else:
                     x[key] = torch.tensor([state[key] for state in list_of_states], device=device)
-            except ValueError:
-                pass
             except KeyError:
-                pass
+                warnings.warn('KeyError while creating StateArray for key "{}", omitting.'.format(key))
+            except ValueError:
+                warnings.warn('ValueError while creating StateArray for key "{}", omitting.'.format(key))
+            except TypeError:
+                warnings.warn('TypeError while creating StateArray for key "{}", omitting.'.format(key))
+
         return StateArray(x, shape, device=device)
 
     def apply(self, model, *keys):

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 import numpy as np
 import torch
 import torch_testing as tt
@@ -169,6 +170,37 @@ class StateArrayTest(unittest.TestCase):
         state = state.view((2, 3))
         self.assertEqual(state.shape, (2, 3))
         self.assertEqual(state.observation.shape, (2, 3, 3, 4))
+
+    def test_key_error(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            StateArray.array([
+                State({
+                    'observation': torch.tensor([1, 2]),
+                    'other_key': True
+                }),
+                State({
+                    'observation': torch.tensor([1, 2]),
+                }),
+            ])
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].message.args[0], 'KeyError while creating StateArray for key "other_key", omitting.')
+
+    def test_type_error(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            StateArray.array([
+                State({
+                    'observation': torch.tensor([1, 2]),
+                    'other_key': torch.tensor([1])
+                }),
+                State({
+                    'observation': torch.tensor([1, 2]),
+                    'other_key': 5.
+                }),
+            ])
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].message.args[0], 'TypeError while creating StateArray for key "other_key", omitting.')
 
 
 if __name__ == "__main__":

--- a/all/experiments/parallel_env_experiment.py
+++ b/all/experiments/parallel_env_experiment.py
@@ -61,9 +61,10 @@ class ParallelEnvExperiment(Experiment):
 
     def test(self, episodes=100):
         test_agent = self._preset.test_agent()
+        env = self._envs[0].duplicate(1)[0]
         returns = []
         for episode in range(episodes):
-            episode_return = self._run_test_episode(test_agent)
+            episode_return = self._run_test_episode(test_agent, env)
             returns.append(episode_return)
             self._log_test_episode(episode, episode_return)
         self._log_test(returns)
@@ -117,9 +118,8 @@ class ParallelEnvExperiment(Experiment):
             device=self._envs[0].device
         )
 
-    def _run_test_episode(self, test_agent):
+    def _run_test_episode(self, test_agent, env):
         # initialize the episode
-        env = self._envs[0].duplicate(1)[0]
         state = env.reset()
         action = test_agent.act(state)
         returns = 0

--- a/all/policies/gaussian.py
+++ b/all/policies/gaussian.py
@@ -10,15 +10,16 @@ class GaussianPolicy(Approximation):
     A Gaussian stochastic policy.
 
     This policy will choose actions from a distribution represented by a spherical Gaussian.
-    The first n outputs the model will be squashed to [-1, 1] through a tanh function, and then
-    scaled to the given action_space, and the remaining n outputs will define the amount of noise added.
+    The first n outputs of the model are the mean of the distribution and the last n outputs are the log variance.
+    The output will be centered and scaled to the size of the given space, but the output will not be clipped.
+    For example, for an output range of [-1, 1], the center is 0 and the scale is 1.
 
     Args:
         model (torch.nn.Module): A Pytorch module representing the policy network.
             The input shape should be the same as the shape of the state (or feature) space,
             and the output shape should be double the size of the the action space.
             The first n outputs will be the unscaled mean of the action for each dimension,
-            and the second n outputs will be the logarithm of the variance.
+            and the last n outputs will be the logarithm of the variance.
         optimizer (torch.optim.Optimizer): A optimizer initialized with the
             model parameters, e.g. SGD, Adam, RMSprop, etc.
         action_space (gym.spaces.Box): The Box representing the action space.
@@ -50,13 +51,10 @@ class GaussianPolicyNetwork(RLNetwork):
     def forward(self, state):
         outputs = super().forward(state)
         action_dim = outputs.shape[-1] // 2
-        means = self._squash(outputs[..., 0:action_dim])
-        logvars = outputs[..., action_dim:] * self._scale
-        std = logvars.exp_()
-        return Independent(Normal(means, std), 1)
-
-    def _squash(self, x):
-        return torch.tanh(x) * self._scale + self._center
+        means = outputs[..., 0:action_dim]
+        logvars = outputs[..., action_dim:]
+        std = (0.5 * logvars).exp_()
+        return Independent(Normal(means + self._center, std * self._scale), 1)
 
     def to(self, device):
         self._center = self._center.to(device)

--- a/all/policies/gaussian_test.py
+++ b/all/policies/gaussian_test.py
@@ -60,10 +60,10 @@ class TestGaussian(unittest.TestCase):
     def test_eval(self):
         state = State(torch.randn(1, STATE_DIM))
         dist = self.policy.no_grad(state)
-        tt.assert_almost_equal(dist.mean, torch.tensor([[-0.233, 0.459, -0.058]]), decimal=3)
-        tt.assert_almost_equal(dist.entropy(), torch.tensor([4.251]), decimal=3)
+        tt.assert_almost_equal(dist.mean, torch.tensor([[-0.237, 0.497, -0.058]]), decimal=3)
+        tt.assert_almost_equal(dist.entropy(), torch.tensor([4.254]), decimal=3)
         best = self.policy.eval(state).sample()
-        tt.assert_almost_equal(best, torch.tensor([[-0.977, -1.05, 0.311]]), decimal=3)
+        tt.assert_almost_equal(best, torch.tensor([[-0.888, -0.887,  0.404]]), decimal=3)
 
 
 if __name__ == '__main__':

--- a/all/policies/gaussian_test.py
+++ b/all/policies/gaussian_test.py
@@ -63,7 +63,7 @@ class TestGaussian(unittest.TestCase):
         tt.assert_almost_equal(dist.mean, torch.tensor([[-0.237, 0.497, -0.058]]), decimal=3)
         tt.assert_almost_equal(dist.entropy(), torch.tensor([4.254]), decimal=3)
         best = self.policy.eval(state).sample()
-        tt.assert_almost_equal(best, torch.tensor([[-0.888, -0.887,  0.404]]), decimal=3)
+        tt.assert_almost_equal(best, torch.tensor([[-0.888, -0.887, 0.404]]), decimal=3)
 
 
 if __name__ == '__main__':

--- a/all/presets/continuous/models/__init__.py
+++ b/all/presets/continuous/models/__init__.py
@@ -5,6 +5,7 @@ All models assume that a feature representing the
 current timestep is used in addition to the features
 received from the environment.
 '''
+import torch
 from all import nn
 
 
@@ -48,11 +49,19 @@ def fc_soft_policy(env, hidden1=400, hidden2=300):
     )
 
 
-def fc_policy(env, hidden1=400, hidden2=300):
-    return nn.Sequential(
-        nn.Linear(env.state_space.shape[0] + 1, hidden1),
-        nn.ReLU(),
-        nn.Linear(hidden1, hidden2),
-        nn.ReLU(),
-        nn.Linear(hidden2, env.action_space.shape[0] * 2)
-    )
+class fc_policy(nn.Module):
+    def __init__(self, env, hidden1=400, hidden2=300):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Linear(env.state_space.shape[0] + 1, hidden1),
+            nn.Tanh(),
+            nn.Linear(hidden1, hidden2),
+            nn.Tanh(),
+            nn.Linear(hidden2, env.action_space.shape[0])
+        )
+        self.log_stds = nn.Parameter(torch.zeros(env.action_space.shape[0]))
+
+    def forward(self, x):
+        means = self.model(x)
+        stds = self.log_stds.expand(*means.shape)
+        return torch.cat((means, stds), 1)

--- a/all/presets/continuous/models/__init__.py
+++ b/all/presets/continuous/models/__init__.py
@@ -47,23 +47,11 @@ def fc_soft_policy(env, hidden1=400, hidden2=300):
         nn.Linear0(hidden2, env.action_space.shape[0] * 2),
     )
 
-
-def fc_actor_critic(env, hidden1=400, hidden2=300):
-    features = nn.Sequential(
+def fc_policy(env, hidden1=400, hidden2=300):
+    return nn.Sequential(
         nn.Linear(env.state_space.shape[0] + 1, hidden1),
         nn.ReLU(),
-    )
-
-    v = nn.Sequential(
-        nn.Linear(hidden1, hidden2),
-        nn.ReLU(),
-        nn.Linear(hidden2, 1)
-    )
-
-    policy = nn.Sequential(
         nn.Linear(hidden1, hidden2),
         nn.ReLU(),
         nn.Linear(hidden2, env.action_space.shape[0] * 2)
     )
-
-    return features, v, policy

--- a/all/presets/continuous/models/__init__.py
+++ b/all/presets/continuous/models/__init__.py
@@ -47,6 +47,7 @@ def fc_soft_policy(env, hidden1=400, hidden2=300):
         nn.Linear0(hidden2, env.action_space.shape[0] * 2),
     )
 
+
 def fc_policy(env, hidden1=400, hidden2=300):
     return nn.Sequential(
         nn.Linear(env.state_space.shape[0] + 1, hidden1),

--- a/all/presets/continuous/ppo.py
+++ b/all/presets/continuous/ppo.py
@@ -2,12 +2,12 @@ import copy
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR
 from all.agents import PPO, PPOTestAgent
-from all.approximation import VNetwork, FeatureNetwork
+from all.approximation import VNetwork, FeatureNetwork, Identity
 from all.bodies import TimeFeature
 from all.logging import DummyWriter
 from all.optim import LinearScheduler
 from all.policies import GaussianPolicy
-from .models import fc_actor_critic
+from .models import fc_policy, fc_v
 from ..builder import preset_builder
 from ..preset import Preset
 
@@ -33,7 +33,8 @@ default_hyperparameters = {
     # GAE settings
     "lam": 0.95,
     # Model construction
-    "ac_model_constructor": fc_actor_critic
+    "value_model_constructor": fc_v,
+    "policy_model_constructor": fc_policy,
 }
 
 
@@ -59,16 +60,15 @@ class PPOContinuousPreset(Preset):
         n_envs (int): Number of parallel actors.
         n_steps (int): Length of each rollout.
         lam (float): The Generalized Advantage Estimate (GAE) decay parameter.
-        ac_model_constructor (function): The function used to construct the neural feature, value and policy model.
+        value_model_constructor (function): The function used to construct the neural value model.
+        policy_model_constructor (function): The function used to construct the neural policy model.
     """
 
     def __init__(self, env, device="cuda", **hyperparameters):
         hyperparameters = {**default_hyperparameters, **hyperparameters}
         super().__init__(hyperparameters["n_envs"])
-        feature_model, value_model, policy_model = hyperparameters["ac_model_constructor"](env)
-        self.feature_model = feature_model.to(device)
-        self.value_model = value_model.to(device)
-        self.policy_model = policy_model.to(device)
+        self.value_model = hyperparameters["value_model_constructor"](env).to(device)
+        self.policy_model = hyperparameters["policy_model_constructor"](env).to(device)
         self.device = device
         self.action_space = env.action_space
         self.hyperparameters = hyperparameters
@@ -76,20 +76,10 @@ class PPOContinuousPreset(Preset):
     def agent(self, writer=DummyWriter(), train_steps=float('inf')):
         n_updates = train_steps * self.hyperparameters['epochs'] * self.hyperparameters['minibatches'] / (self.hyperparameters['n_steps'] * self.hyperparameters['n_envs'])
 
-        feature_optimizer = Adam(self.feature_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
         value_optimizer = Adam(self.value_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
         policy_optimizer = Adam(self.policy_model.parameters(), lr=self.hyperparameters['lr'], eps=self.hyperparameters['eps'])
 
-        features = FeatureNetwork(
-            self.feature_model,
-            feature_optimizer,
-            clip_grad=self.hyperparameters['clip_grad'],
-            scheduler=CosineAnnealingLR(
-                feature_optimizer,
-                n_updates
-            ),
-            writer=writer
-        )
+        features = Identity(self.device)
 
         v = VNetwork(
             self.value_model,
@@ -138,9 +128,8 @@ class PPOContinuousPreset(Preset):
         ))
 
     def test_agent(self):
-        feature = FeatureNetwork(copy.deepcopy(self.feature_model))
         policy = GaussianPolicy(copy.deepcopy(self.policy_model), space=self.action_space)
-        return TimeFeature(PPOTestAgent(feature, policy))
+        return TimeFeature(PPOTestAgent(Identity(self.device), policy))
 
 
 ppo = preset_builder('ppo', default_hyperparameters, PPOContinuousPreset)


### PR DESCRIPTION
Adds an `Identity` Approximation object,. The most common case where this may be used is when a user wishes to not share features when an Agent expects a shared feature network.

This PR makes some minor modifications to the continuous PPO preset, making it closer to the implementation in the original paper:

1. The preset now does not use a shared feature layer, meaning the policy and value networks are completely separate.
2. The network now uses Tanh instead of ReLU, as in the original paper
3. The way `GaussianPolicy` scales the output was changed to not explicitly squash the output

Finally, this PR also includes a minor change to the `ParallelEnvExperiment` which fixes a Pybullet-specific issue.