### PR TITLE
fix n-envs=1 atari bug

### DIFF
--- a/all/bodies/atari.py
+++ b/all/bodies/atari.py
@@ -19,7 +19,7 @@ class EpisodicLives(Body):
         if 'life_lost' not in state:
             return state
 
-        if len(state) == 1:
+        if len(state.shape) == 0:
             if state['life_lost']:
                 return state.update('mask', 0.)
             return state


### PR DESCRIPTION
Was able to track down this issue, it comes from the `EpisodicLives` incorrectly treating a `StateArray` of length 1 as a `State`. I want to add some unit tests around this to avoid issues in the future.