### PR TITLE
Bufix/sac temperature

### DIFF
--- a/all/agents/sac.py
+++ b/all/agents/sac.py
@@ -98,7 +98,7 @@ class SAC(Agent):
 
             # adjust temperature
             temperature_grad = (_log_probs + self.entropy_target).mean()
-            self.temperature += self.lr_temperature * temperature_grad.detach()
+            self.temperature = max(0, self.temperature + self.lr_temperature * temperature_grad.detach())
 
             # additional debugging info
             self.writer.add_loss('entropy', -_log_probs.mean())


### PR DESCRIPTION
The temperature for SAC could in same cases drop below 0, in which case the variance of the policy very quickly increases. This ensures that it never goes below 0.