### PR TITLE
fixed store_device issue

### DIFF
--- a/all/bodies/vision.py
+++ b/all/bodies/vision.py
@@ -69,10 +69,9 @@ class LazyState(State):
         x = {}
         for k in self.keys():
             if not k == key:
-                x[k] = super().__getitem__(k)
+                x[k] = dict.__getitem__(self, k)
         x[key] = value
-        state = LazyState(x, device=self.device)
-        state.to_cache = self.to_cache
+        state = LazyState.from_state(x, x['observation'], self.to_cache)
         return state
 
     def to(self, device):

--- a/all/memory/replay_buffer.py
+++ b/all/memory/replay_buffer.py
@@ -99,7 +99,7 @@ class PrioritizedReplayBuffer(ExperienceReplayBuffer, Schedulable):
         if state is None or state.done:
             return
         idx = self.pos
-        super()._add((state, action, next_state))
+        super().store(state, action, next_state)
         self._it_sum[idx] = self._max_priority ** self._alpha
         self._it_min[idx] = self._max_priority ** self._alpha
 


### PR DESCRIPTION
The store_device parameter did not work on prioritized replay buffers. Now it does. 