### PR TITLE
Fixed the path to trained model when using scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and opening your browser to http://localhost:6006.
 Once the model is trained to your satisfaction, you can watch the trained model play using:
 
 ```
-all-watch-atari Breakout "runs/_a2c [id]"
+all-watch-atari Breakout "runs/a2c_[id]/preset.pt"
 ```
 
 where `id` is the ID of your particular run. You should should be able to find it using tab completion or by looking in the `runs` directory.


### PR DESCRIPTION
When using the `all-atari` or `all-classic` scripts the model is saved to `preset.pt` file, which can only be loaded by refering to the full path.
The documentation wasn't clear that you need to include a full path (and not just the directory).

I added explicit model name and fixed the underscore (should come after the algorithm name).