### PR TITLE
updated default save freq in MultiAgentExperiment

### DIFF
--- a/all/experiments/multiagent_env_experiment.py
+++ b/all/experiments/multiagent_env_experiment.py
@@ -29,7 +29,7 @@ class MultiagentEnvExperiment():
             name=None,
             quiet=False,
             render=False,
-            save_freq=100,
+            save_freq=float('inf'),
             train_steps=float('inf'),
             write_loss=True,
             writer="tensorboard"


### PR DESCRIPTION
The default save freq of 100 in multiagentexperiment was causing my disk to fill up when I was running experiments. This PR sets the default to inf.