### PR TITLE
Feature/batched calculations

### DIFF
--- a/all/agents/ppo.py
+++ b/all/agents/ppo.py
@@ -85,10 +85,10 @@ class PPO(ParallelAgent):
             states, actions, advantages = self._buffer.advantages(next_states)
 
             # compute target values
-            features = states.batch_execute(self.comp_batch_size, self.features.no_grad)
+            features = states.batch_execute(self.compute_batch_size, self.features.no_grad)
             features['actions'] = actions
-            pi_0 = features.batch_execute(self.comp_batch_size, lambda s: self.policy.no_grad(s).log_prob(s['actions']))
-            targets = features.batch_execute(self.comp_batch_size, self.v.no_grad) + advantages
+            pi_0 = features.batch_execute(self.compute_batch_size, lambda s: self.policy.no_grad(s).log_prob(s['actions']))
+            targets = features.batch_execute(self.compute_batch_size, self.v.no_grad) + advantages
 
             # train for several epochs
             for _ in range(self.epochs):

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -358,13 +358,13 @@ class StateArray(State):
         return self['mask']
 
     def __getitem__(self, key):
-        if isinstance(key, slice):
+        if isinstance(key, slice) or isinstance(key, int):
             shape = self['mask'][key].shape
+            if len(shape) == 0:
+                return State({k: v[key] for (k, v) in self.items()}, device=self.device)
             return StateArray({k: v[key] for (k, v) in self.items()}, shape, device=self.device)
-        if isinstance(key, int):
-            return State({k: v[key] for (k, v) in self.items()}, device=self.device)
         if torch.is_tensor(key):
-            # some things may get los
+            # some things may get lost
             d = {}
             shape = self['mask'][key].shape
             for (k, v) in self.items():

--- a/all/core/state.py
+++ b/all/core/state.py
@@ -403,14 +403,6 @@ class StateArray(State):
             d[key] = torch.cat([state_array[key] for state_array in state_array_list], axis=axis)
         return StateArray(d, new_shape, device=state_array_list[0].device)
 
-    def flatten_for_execution(self, fn):
-        flat_size = np.prod(self.shape)
-        flat_data = self.view((flat_size,))
-        out = fn(flat_data)
-        assert out.shape[0] == flat_size, "first dimension out output of flatten_for_execution expected to match input"
-        spread = out.view(self.shape + out.shape[1:])
-        return spread
-
     def batch_execute(self, minibatch_size, fn):
         '''
         execute in batches to reduce memory consumption

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -177,30 +177,31 @@ class StateArrayTest(unittest.TestCase):
             State(torch.zeros((3, 4))),
             State(torch.zeros((3, 4)))
         ])
-        ones_state = zeros.batch_execute(2, lambda x: StateArray({'observation':x.observation + 1}, x.shape, x.device))
+        ones_state = zeros.batch_execute(2, lambda x: StateArray({'observation': x.observation + 1}, x.shape, x.device))
         ones_tensor = zeros.batch_execute(2, lambda x: x.observation + 1)
         self.assertEqual(ones_state.shape, (3,))
-        self.assertTrue(torch.equal(ones_state.observation, torch.ones((3,3,4))))
-        self.assertTrue(torch.equal(ones_tensor, torch.ones((3,3,4))))
+        self.assertTrue(torch.equal(ones_state.observation, torch.ones((3, 3, 4))))
+        self.assertTrue(torch.equal(ones_tensor, torch.ones((3, 3, 4))))
 
     def test_cat(self):
         i1 = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,))}, shape=(2,))
         i2 = StateArray({'observation': torch.zeros((1, 3, 4)), 'reward': torch.ones((1,))}, shape=(1,))
         cat = StateArray.cat([i1, i2])
         self.assertEqual(cat.shape, (3,))
-        self.assertEqual(cat.observation.shape, (3,3,4))
+        self.assertEqual(cat.observation.shape, (3, 3, 4))
         self.assertEqual(cat.reward.shape, (3,))
 
     def test_cat_axis1(self):
-        i1 = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,3))}, shape=(2,3))
-        i2 = StateArray({'observation': torch.zeros((2, 2, 4)), 'reward': torch.ones((2,2))}, shape=(2,2))
+        i1 = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2, 3))}, shape=(2, 3))
+        i2 = StateArray({'observation': torch.zeros((2, 2, 4)), 'reward': torch.ones((2, 2))}, shape=(2, 2))
         cat = StateArray.cat([i1, i2], axis=1)
-        self.assertEqual(cat.shape, (2,5))
-        self.assertEqual(cat.observation.shape, (2,5,4))
-        self.assertEqual(cat.reward.shape, (2,5))
+        self.assertEqual(cat.shape, (2, 5))
+        self.assertEqual(cat.observation.shape, (2, 5, 4))
+        self.assertEqual(cat.reward.shape, (2, 5))
 
     def test_flatten_for_execution(self):
-        state = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,3))}, shape=(2,3))
+        state = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2, 3))}, shape=(2, 3))
+
         def execute(s):
             self.assertEqual(s.shape, (6,))
             self.assertEqual(s.observation.shape, (6, 4))
@@ -210,7 +211,7 @@ class StateArrayTest(unittest.TestCase):
         self.assertEqual(out.shape, (2, 3,))
         self.assertEqual(out.observation.shape, (2, 3, 4))
         self.assertEqual(out.reward.shape, (2, 3,))
-        self.assertTrue(torch.equal(out.observation, torch.ones((2,3,4))))
+        self.assertTrue(torch.equal(out.observation, torch.ones((2, 3, 4))))
 
     def test_key_error(self):
         with warnings.catch_warnings(record=True) as w:

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -171,6 +171,47 @@ class StateArrayTest(unittest.TestCase):
         self.assertEqual(state.shape, (2, 3))
         self.assertEqual(state.observation.shape, (2, 3, 3, 4))
 
+    def test_batch_exec(self):
+        zeros = StateArray.array([
+            State(torch.zeros((3, 4))),
+            State(torch.zeros((3, 4))),
+            State(torch.zeros((3, 4)))
+        ])
+        ones_state = zeros.batch_execute(2, lambda x: StateArray({'observation':x.observation + 1}, x.shape, x.device))
+        ones_tensor = zeros.batch_execute(2, lambda x: x.observation + 1)
+        self.assertEqual(ones_state.shape, (3,))
+        self.assertTrue(torch.equal(ones_state.observation, torch.ones((3,3,4))))
+        self.assertTrue(torch.equal(ones_tensor, torch.ones((3,3,4))))
+
+    def test_cat(self):
+        i1 = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,))}, shape=(2,))
+        i2 = StateArray({'observation': torch.zeros((1, 3, 4)), 'reward': torch.ones((1,))}, shape=(1,))
+        cat = StateArray.cat([i1, i2])
+        self.assertEqual(cat.shape, (3,))
+        self.assertEqual(cat.observation.shape, (3,3,4))
+        self.assertEqual(cat.reward.shape, (3,))
+
+    def test_cat_axis1(self):
+        i1 = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,3))}, shape=(2,3))
+        i2 = StateArray({'observation': torch.zeros((2, 2, 4)), 'reward': torch.ones((2,2))}, shape=(2,2))
+        cat = StateArray.cat([i1, i2], axis=1)
+        self.assertEqual(cat.shape, (2,5))
+        self.assertEqual(cat.observation.shape, (2,5,4))
+        self.assertEqual(cat.reward.shape, (2,5))
+
+    def test_flatten_for_execution(self):
+        state = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2,3))}, shape=(2,3))
+        def execute(s):
+            self.assertEqual(s.shape, (6,))
+            self.assertEqual(s.observation.shape, (6, 4))
+            self.assertEqual(s.reward.shape, (6,))
+            return s.update('observation', s.observation + 1)
+        out = state.flatten_for_execution(execute)
+        self.assertEqual(out.shape, (2, 3,))
+        self.assertEqual(out.observation.shape, (2, 3, 4))
+        self.assertEqual(out.reward.shape, (2, 3,))
+        self.assertTrue(torch.equal(out.observation, torch.ones((2,3,4))))
+
     def test_key_error(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -199,20 +199,6 @@ class StateArrayTest(unittest.TestCase):
         self.assertEqual(cat.observation.shape, (2, 5, 4))
         self.assertEqual(cat.reward.shape, (2, 5))
 
-    def test_flatten_for_execution(self):
-        state = StateArray({'observation': torch.zeros((2, 3, 4)), 'reward': torch.ones((2, 3))}, shape=(2, 3))
-
-        def execute(s):
-            self.assertEqual(s.shape, (6,))
-            self.assertEqual(s.observation.shape, (6, 4))
-            self.assertEqual(s.reward.shape, (6,))
-            return s.update('observation', s.observation + 1)
-        out = state.flatten_for_execution(execute)
-        self.assertEqual(out.shape, (2, 3,))
-        self.assertEqual(out.observation.shape, (2, 3, 4))
-        self.assertEqual(out.reward.shape, (2, 3,))
-        self.assertTrue(torch.equal(out.observation, torch.ones((2, 3, 4))))
-
     def test_key_error(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/all/experiments/multiagent_env_experiment.py
+++ b/all/experiments/multiagent_env_experiment.py
@@ -29,7 +29,7 @@ class MultiagentEnvExperiment():
             name=None,
             quiet=False,
             render=False,
-            save_freq=100,
+            save_freq=float('inf'),
             train_steps=float('inf'),
             write_loss=True,
             writer="tensorboard"

--- a/all/experiments/multiagent_env_experiment.py
+++ b/all/experiments/multiagent_env_experiment.py
@@ -29,7 +29,7 @@ class MultiagentEnvExperiment():
             name=None,
             quiet=False,
             render=False,
-            save_freq=float('inf'),
+            save_freq=100,
             train_steps=float('inf'),
             write_loss=True,
             writer="tensorboard"

--- a/all/memory/generalized_advantage.py
+++ b/all/memory/generalized_advantage.py
@@ -11,7 +11,8 @@ class GeneralizedAdvantageBuffer(Schedulable):
             n_steps,
             n_envs,
             discount_factor=1,
-            lam=1
+            lam=1,
+            compute_batch_size=256,
     ):
         self.v = v
         self.features = features
@@ -20,6 +21,7 @@ class GeneralizedAdvantageBuffer(Schedulable):
         self.gamma = discount_factor
         self.lam = lam
         self._batch_size = self.n_steps * self.n_envs
+        self.compute_batch_size = compute_batch_size
         self._states = []
         self._actions = []
         self._rewards = []
@@ -49,7 +51,7 @@ class GeneralizedAdvantageBuffer(Schedulable):
         states = State.array(self._states[0:self.n_steps + 1])
         actions = torch.cat(self._actions[:self.n_steps], dim=0)
         rewards = torch.stack(self._rewards[:self.n_steps])
-        _values = self.v.target(self.features.target(states))
+        _values = states.flatten_for_execution(lambda flat_state: flat_state.batch_execute(self.compute_batch_size, lambda s: self.v.target(self.features.target(s))))
         values = _values[0:self.n_steps]
         next_values = _values[1:]
         td_errors = rewards + self.gamma * next_values - values

--- a/all/memory/generalized_advantage.py
+++ b/all/memory/generalized_advantage.py
@@ -51,7 +51,7 @@ class GeneralizedAdvantageBuffer(Schedulable):
         states = State.array(self._states[0:self.n_steps + 1])
         actions = torch.cat(self._actions[:self.n_steps], dim=0)
         rewards = torch.stack(self._rewards[:self.n_steps])
-        _values = states.flatten_for_execution(lambda flat_state: flat_state.batch_execute(self.compute_batch_size, lambda s: self.v.target(self.features.target(s))))
+        _values = states.flatten().batch_execute(self.compute_batch_size, lambda s: self.v.target(self.features.target(s))).view(states.shape)
         values = _values[0:self.n_steps]
         next_values = _values[1:]
         td_errors = rewards + self.gamma * next_values - values


### PR DESCRIPTION
I noticed that PPO was using far more memory than I was expecting, and tracked it down to a number of no_grad and target operations in the generalized advantage wrapper and the PPO agent that had no batching, i.e. all the data was being processed at once, leading to huge blowups in memory, even when `minibatches` was large.

This PR has my proposed solution. It extends the StateArray object with 3 new methods:

* cat (class method): concatenates StateArrays
* state_array.execute_batched(batch_size, fn): executes function batch-wise on data, returns the concatenated state array
* state_array.flatten_for_execution(fn): flattens data before performing function. Used in the generalized advantage buffer so that execute_batched can be successfully applied.