### PR TITLE
Feature/mujoco

### DIFF
--- a/all/core/state_test.py
+++ b/all/core/state_test.py
@@ -87,16 +87,6 @@ class StateTest(unittest.TestCase):
         self.assertEqual(state['coolInfo'], 3.)
         self.assertEqual(state.shape, ())
 
-    def test_from_truncated_gym_step(self):
-        observation = np.array([1, 2, 3])
-        state = State.from_gym((observation, 2., False, True, {'coolInfo': 3.}))
-        tt.assert_equal(state.observation, torch.from_numpy(observation))
-        self.assertEqual(state.mask, 1.)
-        self.assertEqual(state.done, True)
-        self.assertEqual(state.reward, 2.)
-        self.assertEqual(state['coolInfo'], 3.)
-        self.assertEqual(state.shape, ())
-
     def test_as_input(self):
         observation = torch.randn(3, 4)
         state = State(observation)

--- a/all/environments/__init__.py
+++ b/all/environments/__init__.py
@@ -1,22 +1,25 @@
 from ._environment import Environment
 from ._multiagent_environment import MultiagentEnvironment
 from ._vector_environment import VectorEnvironment
-from .gym import GymEnvironment
 from .atari import AtariEnvironment
+from .duplicate_env import DuplicateEnvironment
+from .gym import GymEnvironment
+from .mujoco import MujocoEnvironment
 from .multiagent_atari import MultiagentAtariEnv
 from .multiagent_pettingzoo import MultiagentPettingZooEnv
-from .duplicate_env import DuplicateEnvironment
-from .vector_env import GymVectorEnvironment
 from .pybullet import PybulletEnvironment
+from .vector_env import GymVectorEnvironment
+
 
 __all__ = [
-    "Environment",
-    "MultiagentEnvironment",
-    "GymEnvironment",
     "AtariEnvironment",
-    "MultiagentAtariEnv",
-    "MultiagentPettingZooEnv",
-    "GymVectorEnvironment",
     "DuplicateEnvironment",
+    "Environment",
+    "GymEnvironment",
+    "GymVectorEnvironment",
+    "MultiagentAtariEnv",
+    "MultiagentEnvironment",
+    "MultiagentPettingZooEnv",
+    "MujocoEnvironment",
     "PybulletEnvironment",
 ]

--- a/all/environments/gym.py
+++ b/all/environments/gym.py
@@ -27,9 +27,10 @@ class GymEnvironment(Environment):
     def __init__(self, id, device=torch.device('cpu'), name=None, legacy_gym=False):
         if legacy_gym:
             import gym
-            self._env = gym.make(id)
+            self._gym = gym
         else:
-            self._env = gymnasium.make(id)
+            self._gym = gymnasium
+        self._env = self._gym.make(id)
         self._id = id
         self._name = name if name else id
         self._state = None
@@ -89,9 +90,9 @@ class GymEnvironment(Environment):
 
     def _convert(self, action):
         if torch.is_tensor(action):
-            if isinstance(self.action_space, gymnasium.spaces.Discrete):
+            if isinstance(self.action_space, self._gym.spaces.Discrete):
                 return action.item()
-            if isinstance(self.action_space, gymnasium.spaces.Box):
+            if isinstance(self.action_space, self._gym.spaces.Box):
                 return action.cpu().detach().numpy().reshape(-1)
             raise TypeError("Unknown action space type")
         return action

--- a/all/environments/mujoco.py
+++ b/all/environments/mujoco.py
@@ -1,0 +1,5 @@
+from .gym import GymEnvironment
+
+
+class MujocoEnvironment(GymEnvironment):
+    """Simply inherit the Gym Environment"""

--- a/all/environments/mujoco_test.py
+++ b/all/environments/mujoco_test.py
@@ -1,0 +1,35 @@
+import unittest
+from all.environments import MujocoEnvironment, GymEnvironment
+
+
+class MujocoEnvironmentTest(unittest.TestCase):
+    def test_load_env(self):
+        env = MujocoEnvironment("Ant-v4")
+        self.assertEqual(env.name, 'Ant-v4')
+
+    def test_observation_space(self):
+        env = MujocoEnvironment("Ant-v4")
+        self.assertEqual(env.observation_space.shape, (27,))
+
+    def test_action_space(self):
+        env = MujocoEnvironment("Ant-v4")
+        self.assertEqual(env.action_space.shape, (8,))
+
+    def test_reset(self):
+        env = MujocoEnvironment("Ant-v4")
+        state = env.reset(seed=0)
+        self.assertEqual(state.observation.shape, (27,))
+        self.assertEqual(state.reward, 0.)
+        self.assertFalse(state.done)
+        self.assertEqual(state.mask, 1)
+
+    def test_step(self):
+        env = MujocoEnvironment("Ant-v4")
+        state = env.reset(seed=0)
+        state = env.step(env.action_space.sample())
+        self.assertEqual(state.observation.shape, (27,))
+        self.assertGreater(state.reward, -1.)
+        self.assertLess(state.reward, 1)
+        self.assertNotEqual(state.reward, 0.)
+        self.assertFalse(state.done)
+        self.assertEqual(state.mask, 1)

--- a/all/nn/__init__.py
+++ b/all/nn/__init__.py
@@ -205,6 +205,9 @@ class TanhActionBound(nn.Module):
     def forward(self, x):
         return torch.tanh(x) * self.weight + self.bias
 
+class Float(nn.Module):
+    def forward(self, x):
+        return x.float()
 
 def td_loss(loss):
     def _loss(estimates, errors):

--- a/all/nn/__init__.py
+++ b/all/nn/__init__.py
@@ -205,9 +205,11 @@ class TanhActionBound(nn.Module):
     def forward(self, x):
         return torch.tanh(x) * self.weight + self.bias
 
+
 class Float(nn.Module):
     def forward(self, x):
         return x.float()
+
 
 def td_loss(loss):
     def _loss(estimates, errors):

--- a/all/presets/continuous/models/__init__.py
+++ b/all/presets/continuous/models/__init__.py
@@ -11,6 +11,7 @@ from all import nn
 
 def fc_q(env, hidden1=400, hidden2=300):
     return nn.Sequential(
+        nn.Float(),
         nn.Linear(env.state_space.shape[0] + env.action_space.shape[0] + 1, hidden1),
         nn.ReLU(),
         nn.Linear(hidden1, hidden2),
@@ -21,6 +22,7 @@ def fc_q(env, hidden1=400, hidden2=300):
 
 def fc_v(env, hidden1=400, hidden2=300):
     return nn.Sequential(
+        nn.Float(),
         nn.Linear(env.state_space.shape[0] + 1, hidden1),
         nn.ReLU(),
         nn.Linear(hidden1, hidden2),
@@ -31,6 +33,7 @@ def fc_v(env, hidden1=400, hidden2=300):
 
 def fc_deterministic_policy(env, hidden1=400, hidden2=300):
     return nn.Sequential(
+        nn.Float(),
         nn.Linear(env.state_space.shape[0] + 1, hidden1),
         nn.ReLU(),
         nn.Linear(hidden1, hidden2),
@@ -41,6 +44,7 @@ def fc_deterministic_policy(env, hidden1=400, hidden2=300):
 
 def fc_soft_policy(env, hidden1=400, hidden2=300):
     return nn.Sequential(
+        nn.Float(),
         nn.Linear(env.state_space.shape[0] + 1, hidden1),
         nn.ReLU(),
         nn.Linear(hidden1, hidden2),
@@ -53,6 +57,7 @@ class fc_policy(nn.Module):
     def __init__(self, env, hidden1=400, hidden2=300):
         super().__init__()
         self.model = nn.Sequential(
+            nn.Float(),
             nn.Linear(env.state_space.shape[0] + 1, hidden1),
             nn.Tanh(),
             nn.Linear(hidden1, hidden2),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Chris Nota'
 author = 'Chris Nota'
 
 # The full version, including alpha/beta/rc tags
-release = '0.8.2'
+release = '0.9.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/integration/continuous_test.py
+++ b/integration/continuous_test.py
@@ -1,5 +1,5 @@
 import unittest
-from all.environments import GymEnvironment
+from all.environments import GymEnvironment, PybulletEnvironment, MujocoEnvironment
 from all.presets.continuous import ddpg, ppo, sac
 from validate_agent import validate_agent
 
@@ -7,22 +7,31 @@ from validate_agent import validate_agent
 class TestContinuousPresets(unittest.TestCase):
     def test_ddpg(self):
         validate_agent(
-            ddpg.device('cpu').hyperparameters(replay_start_size=50),
-            GymEnvironment('LunarLanderContinuous-v2')
+            ddpg.device("cpu").hyperparameters(replay_start_size=50),
+            GymEnvironment("LunarLanderContinuous-v2"),
         )
 
     def test_ppo(self):
-        validate_agent(
-            ppo.device('cpu'),
-            GymEnvironment('LunarLanderContinuous-v2')
-        )
+        validate_agent(ppo.device("cpu"), GymEnvironment("LunarLanderContinuous-v2"))
 
     def test_sac(self):
         validate_agent(
-            sac.device('cpu').hyperparameters(replay_start_size=50),
-            GymEnvironment('LunarLanderContinuous-v2')
+            sac.device("cpu").hyperparameters(replay_start_size=50),
+            GymEnvironment("LunarLanderContinuous-v2"),
+        )
+
+    def test_mujoco(self):
+        validate_agent(
+            sac.device("cpu").hyperparameters(replay_start_size=50),
+            MujocoEnvironment("HalfCheetah-v4"),
+        )
+
+    def test_pybullet(self):
+        validate_agent(
+            sac.device("cpu").hyperparameters(replay_start_size=50),
+            PybulletEnvironment("cheetah"),
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras["dev"] = extras["all"] + extras["test"] + extras["docs"]
 
 setup(
     name="autonomous-learning-library",
-    version="0.8.2",
+    version="0.9.0",
     description=("A library for building reinforcement learning agents in Pytorch"),
     packages=find_packages(),
     url="https://github.com/cpnota/autonomous-learning-library.git",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ extras = {
         "pybullet>=3.2.2",
         "gym>=0.10.0,<0.26.0",
     ],
+    "mujoco": [
+        "gymnasium[mujoco]~={}".format(GYM_VERSION),
+    ],
     "ma-atari": [
         "PettingZoo[atari, accept-rom-license]~={}".format(PETTINGZOO_VERSION),
         "supersuit~=3.9.1",
@@ -39,11 +42,12 @@ extras = {
 extras["all"] = (
     extras["atari"]
     + extras["box2d"]
+    + extras["mujoco"]
     + extras["pybullet"]
     + extras["ma-atari"]
     + extras["comet"]
 )
-extras["dev"] = extras["all"] + extras["test"] + extras["docs"] + extras["comet"]
+extras["dev"] = extras["all"] + extras["test"] + extras["docs"]
 
 setup(
     name="autonomous-learning-library",


### PR DESCRIPTION
At long last! Adds Mujoco environment support. `MujocoEnvironment` itself is just for convention; it simply subclasses `GymEnvironment` with no changes. However, because the Mujoco environments output in float64 instead of float32, we need to handle this in our models correctly (we simply convert the inputs to float32 in the first step of our model).