### PR TITLE
Fix key error warnings

### DIFF
--- a/all/environments/atari_test.py
+++ b/all/environments/atari_test.py
@@ -11,7 +11,7 @@ class AtariEnvironmentTest(unittest.TestCase):
         self.assertEqual(state.reward, 0)
         self.assertFalse(state.done)
         self.assertEqual(state.mask, 1)
-        self.assertEqual(state['life_lost'], False)
+        self.assertEqual(state["life_lost"], False)
 
     def test_step(self):
         env = AtariEnvironment("Breakout")

--- a/all/environments/atari_test.py
+++ b/all/environments/atari_test.py
@@ -11,6 +11,7 @@ class AtariEnvironmentTest(unittest.TestCase):
         self.assertEqual(state.reward, 0)
         self.assertFalse(state.done)
         self.assertEqual(state.mask, 1)
+        self.assertEqual(state['life_lost'], False)
 
     def test_step(self):
         env = AtariEnvironment("Breakout")

--- a/all/environments/atari_wrappers.py
+++ b/all/environments/atari_wrappers.py
@@ -180,8 +180,9 @@ class LifeLostEnv(gymnasium.Wrapper):
         self.lives = 0
 
     def reset(self):
+        obs, _ = self.env.reset()
         self.lives = 0
-        return self.env.reset()
+        return obs, {"life_lost": False}
 
     def step(self, action):
         obs, reward, terminated, truncated, _ = self.env.step(action)

--- a/all/environments/gym_wrappers.py
+++ b/all/environments/gym_wrappers.py
@@ -6,6 +6,7 @@ class NoInfoWrapper(gymnasium.Wrapper):
     Wrapper to suppress info and simply return a dict.
     This prevents State.from_gym() from create keys.
     """
+
     def reset(self, seed=None, options=None):
         obs, _ = self.env.reset(seed=seed, options=options)
         return obs, {}

--- a/all/environments/gym_wrappers.py
+++ b/all/environments/gym_wrappers.py
@@ -1,0 +1,15 @@
+import gymnasium
+
+
+class NoInfoWrapper(gymnasium.Wrapper):
+    """
+    Wrapper to suppress info and simply return a dict.
+    This prevents State.from_gym() from create keys.
+    """
+    def reset(self, seed=None, options=None):
+        obs, _ = self.env.reset(seed=seed, options=options)
+        return obs, {}
+
+    def step(self, action):
+        *obs, info = self.env.step(action)
+        return *obs, {}

--- a/all/environments/mujoco.py
+++ b/all/environments/mujoco.py
@@ -7,6 +7,7 @@ from .gym_wrappers import NoInfoWrapper
 
 class MujocoEnvironment(GymEnvironment):
     """A Mujoco Environment"""
+
     def __init__(
         self, id, device=torch.device("cpu"), name=None, no_info=True, **gym_make_kwargs
     ):

--- a/all/environments/mujoco.py
+++ b/all/environments/mujoco.py
@@ -1,5 +1,15 @@
+import gymnasium
+import torch
+
 from .gym import GymEnvironment
+from .gym_wrappers import NoInfoWrapper
 
 
 class MujocoEnvironment(GymEnvironment):
-    """Simply inherit the Gym Environment"""
+    """A Mujoco Environment"""
+    def __init__(
+        self, id, device=torch.device("cpu"), name=None, no_info=True, **gym_make_kwargs
+    ):
+        super().__init__(id, device=device, name=name, **gym_make_kwargs)
+        if no_info:
+            self._env = NoInfoWrapper(self._env)

--- a/all/environments/mujoco.py
+++ b/all/environments/mujoco.py
@@ -1,4 +1,3 @@
-import gymnasium
 import torch
 
 from .gym import GymEnvironment

--- a/all/environments/mujoco_test.py
+++ b/all/environments/mujoco_test.py
@@ -38,12 +38,12 @@ class MujocoEnvironmentTest(unittest.TestCase):
     def test_no_info_wrapper(self):
         env = MujocoEnvironment("Ant-v4")
         state = env.reset(seed=0)
-        self.assertFalse('reward_forward' in state)
+        self.assertFalse("reward_forward" in state)
         state = env.step(env.action_space.sample())
-        self.assertFalse('reward_forward' in state)
+        self.assertFalse("reward_forward" in state)
 
     def test_with_info(self):
         env = MujocoEnvironment("Ant-v4", no_info=False)
         state = env.reset(seed=0)
         state = env.step(env.action_space.sample())
-        self.assertTrue('reward_forward' in state)
+        self.assertTrue("reward_forward" in state)

--- a/all/environments/mujoco_test.py
+++ b/all/environments/mujoco_test.py
@@ -34,3 +34,16 @@ class MujocoEnvironmentTest(unittest.TestCase):
         self.assertNotEqual(state.reward, 0.0)
         self.assertFalse(state.done)
         self.assertEqual(state.mask, 1)
+
+    def test_no_info_wrapper(self):
+        env = MujocoEnvironment("Ant-v4")
+        state = env.reset(seed=0)
+        self.assertFalse('reward_forward' in state)
+        state = env.step(env.action_space.sample())
+        self.assertFalse('reward_forward' in state)
+
+    def test_with_info(self):
+        env = MujocoEnvironment("Ant-v4", no_info=False)
+        state = env.reset(seed=0)
+        state = env.step(env.action_space.sample())
+        self.assertTrue('reward_forward' in state)


### PR DESCRIPTION
This is related to #298 . The Atari and Mujoco environments previously output a lot of `info`, which gets put in the `State` object. This PR limits that info in both cases to avoid the `KeyError` warnings.